### PR TITLE
fix(libthread): copy dir in _runthreadspawn so child gets correct cwd

### DIFF
--- a/src/libthread/exec.c
+++ b/src/libthread/exec.c
@@ -49,7 +49,7 @@ _runthreadspawn(int *fd, char *cmd, char **argv, char *dir)
 		if(e->argv[i] == nil)
 			sysfatal("out of memory");
 	}
-	if(e->dir != nil) {
+	if(dir != nil) {
 		e->dir = strdup(dir);
 		if(e->dir == nil)
 			sysfatal("out of memory");


### PR DESCRIPTION
The condition used the uninitialized e->dir (always nil after mallocz) instead of the dir parameter, so the working directory was never stored in the Execjob. The child then never did chdir(dir) and inherited the parent's cwd. Fix by checking dir != nil when copying into e->dir.