### PR TITLE
acme: implement shift+click to extend selection

### DIFF
--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -671,8 +671,11 @@ mousethread(void *v)
 					wincommit(w, t);
 				else
 					textcommit(t, TRUE);
-				if(m.buttons & 1){
-					textselect(t);
+				if(m.buttons & (1|(1<<Shift))){
+					if(m.buttons & (1<<Shift))
+						textselectextend(t);
+					else
+						textselect(t);
 					if(w)
 						winsettag(w);
 					argtext = t;

--- a/src/cmd/acme/dat.h
+++ b/src/cmd/acme/dat.h
@@ -225,6 +225,7 @@ int		textresize(Text*, Rectangle, int);
 void		textscrdraw(Text*);
 void		textscroll(Text*, int);
 void		textselect(Text*);
+void		textselectextend(Text*);
 int		textselect2(Text*, uint*, uint*, Text**);
 int		textselect23(Text*, uint*, uint*, Image*, int);
 int		textselect3(Text*, uint*, uint*);

--- a/src/cmd/acme/text.c
+++ b/src/cmd/acme/text.c
@@ -1272,6 +1272,85 @@ textframescroll(Text *t, int dl)
 }
 
 
+/*
+ * textselectextend extends the current selection to the mouse click position,
+ * implementing shift+click. The anchor is the end of the selection that the
+ * cursor is NOT at (tracked by cursoratq1, consistent with shift+arrow keys).
+ * If there is no existing selection (q0==q1), the click position becomes the
+ * new cursor and cursoratq1 is reset. After extending, the cursor end is set
+ * to the click position and cursoratq1 is updated accordingly.
+ */
+void
+textselectextend(Text *t)
+{
+	uint q0, q1, click;
+	int atq1;
+
+	/* convert click position to character offset */
+	click = t->org + frcharofpt(&t->fr, mouse->xy);
+	if(click > t->file->b.nc)
+		click = t->file->b.nc;
+
+	q0 = t->q0;
+	q1 = t->q1;
+
+	if(q0 == q1){
+		/*
+		 * No selection: cursor is the anchor. Extend from cursor to click.
+		 */
+		if(click >= q0){
+			q1 = click;
+			atq1 = 1;
+		} else {
+			q0 = click;
+			atq1 = 0;
+		}
+	} else {
+		/*
+		 * Existing selection: determine which end is the cursor (moves)
+		 * and which is the anchor (stays). cursoratq1 tracks this across
+		 * shift+arrow keys; if unset, infer from click proximity.
+		 */
+		if(t->cursoratq1 < 0){
+			if(click <= q0)
+				atq1 = 0;
+			else if(click >= q1)
+				atq1 = 1;
+			else
+				atq1 = (click - q0 > q1 - click) ? 1 : 0;
+		} else {
+			atq1 = t->cursoratq1;
+		}
+
+		/* move cursor end to click, flipping if click crosses anchor */
+		if(atq1){
+			if(click >= q0){
+				q1 = click;
+			} else {
+				q1 = q0;
+				q0 = click;
+				atq1 = 0;
+			}
+		} else {
+			if(click <= q1){
+				q0 = click;
+			} else {
+				q0 = q1;
+				q1 = click;
+				atq1 = 1;
+			}
+		}
+	}
+
+	textsetselect(t, q0, q1);
+	flushimage(display, 1);
+	t->cursoratq1 = atq1;	/* textsetselect clears it; restore */
+
+	/* drain button release */
+	while(mouse->buttons)
+		readmouse(mousectl);
+}
+
 void
 textselect(Text *t)
 {


### PR DESCRIPTION
Shift+button1 extends the current selection to the click position, consistent with how most text editors behave.

The anchor end is determined by cursoratq1 (the same field used by shift+arrow keys), so shift+click and shift+arrow can be freely combined. If the selection is empty, shift+click just moves the cursor. If the click crosses the anchor, the selection flips and cursoratq1 is updated accordingly.

Works in both tag and body of every window.
