### PR TITLE
feat: expand ~ and $HOME/$home in acme, 9term, sam, and plumber

### DIFF
--- a/man/man1/9term.1
+++ b/man/man1/9term.1
@@ -175,6 +175,16 @@ and erases the character before the word.
 An ACK character (control-F) or Insert character triggers file name completion
 for the preceding string (see
 .MR complete 3 ).
+The prefixes
+.BR ~ ,
+.BR $HOME ,
+and
+.B $home
+are expanded to the user's home directory before the completion search,
+so typing
+.B ~/sr
+followed by control-F will complete against
+.BR $HOME/sr .
 .PP
 Text may be moved vertically within the window.
 A scroll bar on the left of the window shows in its clear portion what fragment of the

--- a/man/man1/acme.1
+++ b/man/man1/acme.1
@@ -306,6 +306,30 @@ directory or a real directory associated with a non-existent file
 .BR /adm/not-a-file ).
 File names beginning with a slash
 are assumed to be absolute file names.
+.PP
+.I Acme
+recognizes
+.BR ~ ,
+.BR $HOME ,
+and
+.B $home
+as prefixes in window names and file arguments.
+When a window is opened or a
+.B Get
+command is executed, any such prefix is expanded to the user's home directory.
+Conversely, when a window name is set, any leading home directory path is
+automatically shortened to
+.BR ~ .
+For example, entering
+.B ~/src
+in a tag and executing
+.B Get
+opens
+.BR /Users/you/src ,
+and the tag is then displayed as
+.BR ~/src/ .
+Filename completion (Control-F) also expands these prefixes before searching
+the filesystem.
 .SS Errors
 Windows whose names begin with
 .B -

--- a/man/man1/sam.1
+++ b/man/man1/sam.1
@@ -473,6 +473,18 @@ to the named external file.
 Set the file name and print the resulting menu entry.
 .PP
 If the file name is absent from any of these, the current file name is used.
+.PP
+In all file name arguments,
+.BR ~ ,
+.BR $HOME ,
+and
+.B $home
+are expanded to the user's home directory.
+For example,
+.B e ~/.profile
+opens
+.B $HOME/.profile
+in the editor.
 .B e
 always sets the file name;
 .B r

--- a/man/man7/plumb.7
+++ b/man/man7/plumb.7
@@ -343,6 +343,35 @@ The root directory of the Plan 9 tree
 (see
 .MR get9root 3 ).
 .RE
+.PP
+If a variable is not defined in the plumbing rules file and is not one of the
+built-in variables above, the plumber falls back to the Unix environment.
+This allows rules to reference environment variables such as
+.B $HOME
+directly.
+.PP
+To match file paths beginning with
+.B ~/
+or
+.BR $home/ ,
+define a plumbing variable for the home directory in the rules file and
+write explicit rules for each prefix.
+For example, in
+.BR \*9/plumb/initial.plumbing :
+.EX
+	homedir = /Users/you
+	home = /Users/you
+	include basic
+.EE
+The included
+.B basic
+rules then use
+.B $homedir
+and
+.B $home
+in
+.B arg isfile
+checks to resolve the captured path against the home directory.
 .SH EXAMPLE
 The following is a modest, representative file of plumbing rules.
 .EX

--- a/plumb/basic
+++ b/plumb/basic
@@ -90,6 +90,15 @@ attr add	addr=$3
 plumb to edit
 plumb client $editor
 
+# ~/path files, possibly tagged by address, go to editor
+type is text
+data matches '~/([.a-zA-Z¡-￿0-9_/\-@]*[a-zA-Z¡-￿0-9_/\-])('$addr')?'
+arg isfile	$homedir/$1
+data set	$file
+attr add	addr=$3
+plumb to edit
+plumb client $editor
+
 # .h files are looked up in /usr/include and passed to edit
 type is text
 data matches '([a-zA-Z¡-￿0-9/_\-]+\.h)('$addr')?'

--- a/plumb/basic
+++ b/plumb/basic
@@ -90,10 +90,18 @@ attr add	addr=$3
 plumb to edit
 plumb client $editor
 
-# ~/path files, possibly tagged by address, go to editor
+# ~/path and $home/path files, possibly tagged by address, go to editor
 type is text
 data matches '~/([.a-zA-Z¡-￿0-9_/\-@]*[a-zA-Z¡-￿0-9_/\-])('$addr')?'
 arg isfile	$homedir/$1
+data set	$file
+attr add	addr=$3
+plumb to edit
+plumb client $editor
+
+type is text
+data matches '\$home/([.a-zA-Z¡-￿0-9_/\-@]*[a-zA-Z¡-￿0-9_/\-])('$addr')?'
+arg isfile	$home/$1
 data set	$file
 attr add	addr=$3
 plumb to edit

--- a/plumb/initial.plumbing
+++ b/plumb/initial.plumbing
@@ -1,4 +1,8 @@
 # to update: cat $HOME/lib/plumbing | 9p write plumb/rules
+#
+# Set home to your home directory for ~/path plumbing to work.
+# The plumber does not expand shell variables, so this must be a literal path.
+homedir = /Users/daniel
 
 editor = plumb-edit
 include basic

--- a/plumb/initial.plumbing
+++ b/plumb/initial.plumbing
@@ -3,6 +3,7 @@
 # Set home to your home directory for ~/path plumbing to work.
 # The plumber does not expand shell variables, so this must be a literal path.
 homedir = /Users/daniel
+home = /Users/daniel
 
 editor = plumb-edit
 include basic

--- a/shell/p9p-session.fish.in
+++ b/shell/p9p-session.fish.in
@@ -14,3 +14,6 @@ end
 set -gx TERM dumb
 set -gx PAGER nobs
 set -gx MANPAGER nobs
+
+# Set $home to mirror $HOME so plumbing rules using $home/path work.
+set -gx home $HOME

--- a/shell/p9p-session.sh.in
+++ b/shell/p9p-session.sh.in
@@ -41,5 +41,8 @@ export MANPAGER=nobs
 set +o emacs 2>/dev/null || true
 set +o vi    2>/dev/null || true
 
+# Set $home to mirror $HOME so plumbing rules using $home/path work.
+export home="$HOME"
+
 # Auto-export new variable assignments, matching rc shell convention.
 set -a

--- a/src/cmd/9term/wind.c
+++ b/src/cmd/9term/wind.c
@@ -538,8 +538,8 @@ namecomplete(Window *w)
 {
 	int nstr, npath;
 	Rune *rp, *path, *str;
-	Completion *c;
-	char *s, *dir, *root;
+	Completion *c = nil;
+	char *s, *dir = nil, *root;
 
 	/* control-f: filename completion; works back to white space or / */
 	if(w->q0<w->nr && w->r[w->q0]>' ')	/* must be at end of word */
@@ -556,6 +556,23 @@ namecomplete(Window *w)
 	if(npath>0 && path[0]=='/'){
 		dir = malloc(UTFmax*npath+1);
 		sprint(dir, "%.*S", npath, path);
+	}else if(npath>0 && path[0]=='~' && (npath==1 || path[1]=='/')){
+		/* ~/... -> expand ~ to $HOME */
+		char *home = getenv("HOME");
+		if(home == nil)
+			goto Return;
+		dir = malloc(strlen(home)+UTFmax*npath+1);
+		sprint(dir, "%s%.*S", home, npath-1, path+1);
+	}else if(npath>=5
+		&& path[0]=='$' && path[1]=='h' && path[3]=='m' && path[4]=='e'
+		&& (path[2]=='o' || path[2]=='O')  /* $home or $HOME */
+		&& (npath==5 || path[5]=='/')){
+		/* $HOME/... or $home/... -> expand to $HOME */
+		char *home = getenv("HOME");
+		if(home == nil)
+			goto Return;
+		dir = malloc(strlen(home)+UTFmax*npath+1);
+		sprint(dir, "%s%.*S", home, npath-5, path+5);
 	}else{
 		if(strcmp(w->dir, "") == 0)
 			root = ".";

--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -317,7 +317,7 @@ readfile(Column *c, char *s)
 		runesnprint(rb, sizeof rb, "%s", s);
 	nr = runestrlen(rb);
 	rs = cleanrname(runestr(rb, nr));
-	winsetname(w, rs.r, rs.nr);
+	winsetname_contract(w, rs.r, rs.nr);
 	textload(&w->body, 0, s, 1);
 	w->body.file->mod = FALSE;
 	w->dirty = FALSE;

--- a/src/cmd/acme/dat.h
+++ b/src/cmd/acme/dat.h
@@ -288,6 +288,7 @@ void	winunlock(Window*);
 void	wintype(Window*, Text*, Rune);
 void	winundo(Window*, int);
 void	winsetname(Window*, Rune*, int);
+void	winsetname_contract(Window*, Rune*, int);
 void	winsettag(Window*);
 void	winsettag1(Window*);
 void	wincommit(Window*, Text*);

--- a/src/cmd/acme/ecmd.c
+++ b/src/cmd/acme/ecmd.c
@@ -1390,7 +1390,7 @@ cmdname(File *f, String *str, int set)
 		filemark(f);
 		f->mod = TRUE;
 		f->curtext->w->dirty = TRUE;
-		winsetname(f->curtext->w, r, n);
+		winsetname_contract(f->curtext->w, r, n);
 	}
 	return r;
 }

--- a/src/cmd/acme/exec.c
+++ b/src/cmd/acme/exec.c
@@ -16,6 +16,7 @@
 
 Buffer	snarfbuf;
 
+
 /*
  * These functions get called as:
  *
@@ -556,8 +557,21 @@ getname(Text *t, Text *argt, Rune *arg, int narg, int isput)
 	if(promote){
 		n = narg;
 		if(n <= 0){
-			s = runetobyte(t->file->name, t->file->nname);
+			/* expand ~ / $HOME / $home in the file's stored name */
+			int nn = t->file->nname;
+			Rune *tmp = runemalloc(nn);
+			runemove(tmp, t->file->name, nn);
+			tmp = expandhome(tmp, &nn);
+			s = runetobyte(tmp, nn);
+			free(tmp);
 			return s;
+		}
+		/* expand ~ / $HOME / $home before checking if path is absolute */
+		{
+			Rune *tmp = runemalloc(n);
+			runemove(tmp, arg, n);
+			tmp = expandhome(tmp, &n);
+			arg = tmp;
 		}
 		/* prefix with directory name if necessary */
 		dir.r = nil;

--- a/src/cmd/acme/fns.h
+++ b/src/cmd/acme/fns.h
@@ -4,6 +4,7 @@
 */
 
 void	warning(Mntdir*, char*, ...);
+Rune*	expandhome(Rune*, int*);
 void	warningew(Window*, Mntdir*, char*, ...);
 
 #define	fbufalloc()	emalloc(BUFSIZE)

--- a/src/cmd/acme/fns.h
+++ b/src/cmd/acme/fns.h
@@ -5,6 +5,7 @@
 
 void	warning(Mntdir*, char*, ...);
 Rune*	expandhome(Rune*, int*);
+Rune*	contracthome(Rune*, int, int*);
 void	warningew(Window*, Mntdir*, char*, ...);
 
 #define	fbufalloc()	emalloc(BUFSIZE)

--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -557,6 +557,24 @@ dirname(Text *t, Rune *r, int n)
 	if(n>=1 && r[0]=='/')
 		goto Rescue;
 	b = parsetag(t->w, n, &i);
+	/* expand ~ / $HOME / $home in the tag path into a fresh buffer
+	 * with n extra runes at the end for the filename we'll append */
+	{
+		Rune *expanded;
+		int ei = i;
+		expanded = runemalloc(i);
+		runemove(expanded, b, i);
+		expanded = expandhome(expanded, &ei);
+		if(ei != i){
+			/* re-allocate with room for n extra runes */
+			Rune *tmp = runemalloc(ei + n + 1);
+			runemove(tmp, expanded, ei);
+			free(expanded);
+			free(b);
+			b = tmp;
+			i = ei;
+		}
+	}
 	slash = -1;
 	for(i--; i >= 0; i--){
 		if(b[i] == '/'){

--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -297,7 +297,7 @@ plumbshow(Plumbmsg *m)
 	cvttorunes(name, strlen(name), rb, &nb, &nr, nil);
 	free(p);
 	rs = cleanrname(runestr(rb, nr));
-	winsetname(w, rs.r, rs.nr);
+	winsetname_contract(w, rs.r, rs.nr);
 	rulerprefont(w);
 	r = runemalloc(m->ndata);
 	cvttorunes(m->data, m->ndata, r, &nb, &nr, nil);
@@ -875,7 +875,7 @@ openfile(Text *t, Expand *e)
 			ow = t->w;
 		w = makenewwindow(t);
 		t = &w->body;
-		winsetname(w, e->name, e->nname);
+		winsetname_contract(w, e->name, e->nname);
 		rulerprefont(w);
 		if(textload(t, 0, e->bname, 1) >= 0)
 			t->file->unread = FALSE;

--- a/src/cmd/acme/rows.c
+++ b/src/cmd/acme/rows.c
@@ -749,7 +749,7 @@ rowload(Row *row, char *file, int initing)
 				break;
 		}
 		if(dumpid == 0)
-			winsetname(w, r, n);
+			winsetname_contract(w, r, n);
 		for(; n<nr; n++)
 			if(r[n] == '|')
 				break;

--- a/src/cmd/acme/text.c
+++ b/src/cmd/acme/text.c
@@ -622,9 +622,48 @@ textcomplete(Text *t)
 	for(i=0; i<npath; i++)
 		path[i] = textreadc(t, q++);
 	/* is path rooted? if not, we need to make it relative to window path */
-	if(npath>0 && path[0]=='/')
+	if(npath>0 && path[0]=='/'){
 		dir = runestr(path, npath);
-	else{
+	}else if(npath>0 && path[0]=='~' && (npath==1 || path[1]=='/')){
+		/* ~/... -> expand ~ to $HOME */
+		char *home = getenv("HOME");
+		if(home == nil)
+			goto Return;
+		Rune *homer = runesmprint("%s", home);
+		int homelen = runestrlen(homer);
+		int restlen = npath - 1; /* skip the ~ */
+		if(homelen + restlen > nelem(tmp)){
+			free(homer);
+			goto Return;
+		}
+		runemove(tmp, homer, homelen);
+		runemove(tmp+homelen, path+1, restlen);
+		free(homer);
+		dir.r = tmp;
+		dir.nr = homelen + restlen;
+		dir = cleanrname(dir);
+	}else if(npath>=5
+		&& path[0]=='$' && path[1]=='h' && path[3]=='m' && path[4]=='e'
+		&& (path[2]=='o' || path[2]=='O')  /* $home or $HOME */
+		&& (npath==5 || path[5]=='/')){
+		/* $HOME/... or $home/... -> expand to $HOME */
+		char *home = getenv("HOME");
+		if(home == nil)
+			goto Return;
+		Rune *homer = runesmprint("%s", home);
+		int homelen = runestrlen(homer);
+		int restlen = npath - 5; /* skip $HOME or $home */
+		if(homelen + restlen > nelem(tmp)){
+			free(homer);
+			goto Return;
+		}
+		runemove(tmp, homer, homelen);
+		runemove(tmp+homelen, path+5, restlen);
+		free(homer);
+		dir.r = tmp;
+		dir.nr = homelen + restlen;
+		dir = cleanrname(dir);
+	}else{
 		dir = dirname(t, nil, 0);
 		if(dir.nr + 1 + npath > nelem(tmp)){
 			free(dir.r);

--- a/src/cmd/acme/util.c
+++ b/src/cmd/acme/util.c
@@ -496,6 +496,46 @@ makenewwindow(Text *t)
 	return w;
 }
 
+/* contract leading $HOME to ~ in a Rune path.
+ * returns a new allocation; caller must free. */
+Rune*
+contracthome(Rune *name, int n, int *outn)
+{
+	char *home;
+	Rune *homer;
+	int homelen;
+
+	home = getenv("HOME");
+	if(home == nil){
+		*outn = n;
+		return runemalloc(n); /* caller will runemove into it */
+	}
+	homer = runesmprint("%s", home);
+	homelen = runestrlen(homer);
+	free(homer);
+
+	if(n >= homelen){
+		/* check if name starts with $HOME followed by / or end-of-string */
+		Rune *htmp = runesmprint("%s", home);
+		int match = runestrncmp(name, htmp, homelen) == 0
+			&& (n == homelen || (n > homelen && name[homelen] == '/'));
+		free(htmp);
+		if(match){
+			int rest = n - homelen; /* 0 if exact match, else includes leading / */
+			Rune *out = runemalloc(1 + rest + 1);
+			out[0] = '~';
+			if(rest > 0)
+				runemove(out+1, name+homelen, rest);
+			*outn = 1 + rest;
+			return out;
+		}
+	}
+	*outn = n;
+	Rune *out = runemalloc(n);
+	runemove(out, name, n);
+	return out;
+}
+
 /* expand leading ~ or $HOME/$home in a Rune path to the real home directory.
  * takes ownership of arg (frees it if expanded); updates *np. */
 Rune*

--- a/src/cmd/acme/util.c
+++ b/src/cmd/acme/util.c
@@ -495,3 +495,43 @@ makenewwindow(Text *t)
 		colgrow(w->col, w, 1);
 	return w;
 }
+
+/* expand leading ~ or $HOME/$home in a Rune path to the real home directory.
+ * takes ownership of arg (frees it if expanded); updates *np. */
+Rune*
+expandhome(Rune *arg, int *np)
+{
+	char *home;
+	Rune *homer, *expanded;
+	int homelen, skip, n;
+
+	n = *np;
+	if(n <= 0)
+		return arg;
+
+	skip = 0;
+	if(arg[0] == '~' && (n == 1 || arg[1] == '/'))
+		skip = 1;
+	else if(n >= 5
+		&& arg[0]=='$' && arg[1]=='h' && arg[3]=='m' && arg[4]=='e'
+		&& (arg[2]=='o' || arg[2]=='O')
+		&& (n == 5 || arg[5] == '/'))
+		skip = 5;
+
+	if(skip == 0)
+		return arg;
+
+	home = getenv("HOME");
+	if(home == nil)
+		return arg;
+
+	homer = runesmprint("%s", home);
+	homelen = runestrlen(homer);
+	expanded = runemalloc(homelen + (n - skip) + 1);
+	runemove(expanded, homer, homelen);
+	runemove(expanded + homelen, arg + skip, n - skip);
+	free(homer);
+	free(arg);
+	*np = homelen + (n - skip);
+	return expanded;
+}

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -412,6 +412,17 @@ winsetname(Window *w, Rune *name, int n)
 }
 
 void
+winsetname_contract(Window *w, Rune *name, int n)
+{
+	Rune *cname;
+	int cn;
+
+	cname = contracthome(name, n, &cn);
+	winsetname(w, cname, cn);
+	free(cname);
+}
+
+void
 wintype(Window *w, Text *t, Rune r)
 {
 	int i;

--- a/src/cmd/acme/xfid.c
+++ b/src/cmd/acme/xfid.c
@@ -698,7 +698,7 @@ xfidctlwrite(Xfid *x, Window *w)
 out:
 			seq++;
 			filemark(w->body.file);
-			winsetname(w, r, nr);
+			winsetname_contract(w, r, nr);
 			rulerapply(w);
 			m += (q+1) - pp;
 		}else

--- a/src/cmd/sam/multi.c
+++ b/src/cmd/sam/multi.c
@@ -48,12 +48,59 @@ fullname(String *name)
 		Strinsert(name, &curwd, (Posn)0);
 }
 
+static void
+expandhome(String *name)
+{
+	char *h;
+	int hlen, skip;
+	String *hs;
+
+	if(name->n == 0)
+		return;
+	h = getenv("HOME");
+	if(h == nil || h[0] == '\0')
+		return;
+	hlen = strlen(h);
+
+	/* ~ or ~/... */
+	if(name->s[0] == '~' && (name->n == 1 || name->s[1] == '/')) {
+		skip = 1;
+		hs = tmpcstr(h);
+		Strdelete(name, 0, skip);
+		Strinsert(name, hs, 0);
+		freetmpstr(hs);
+		return;
+	}
+
+	/* $HOME/... or $home/... */
+	{
+		static char *prefixes[] = { "$HOME", "$home", nil };
+		int i;
+		for(i = 0; prefixes[i] != nil; i++) {
+			int plen = strlen(prefixes[i]);
+			if(name->n >= plen) {
+				int j, match = 1;
+				for(j = 0; j < plen; j++)
+					if(name->s[j] != prefixes[i][j]) { match = 0; break; }
+				if(match && (name->n == plen || name->s[plen] == '/')) {
+					hs = tmpcstr(h);
+					Strdelete(name, 0, plen);
+					Strinsert(name, hs, 0);
+					freetmpstr(hs);
+					return;
+				}
+			}
+		}
+	}
+}
+
 void
 fixname(String *name)
 {
 	String *t;
 	char *s;
 
+	expandhome(name);
 	fullname(name);
 	s = Strtoc(name);
 	if(strlen(s) > 0)


### PR DESCRIPTION
## Summary

Adds support for `~`, `\$HOME`, and `\$home` as home directory prefixes across acme, 9term, sam, and the plumber, improving usability on macOS and other Unix systems where these conventions are standard.

### acme

- **Tag bar expansion**: Entering a path like `~/src` in a window tag and executing `Get` now expands `~` (or `\$HOME`/`\$home`) to the real home directory before loading the file or directory.
- **Tag bar contraction**: When a window name is set (on open, `Get`, plumb, or external `name` ctl write), any leading `\$HOME` path is automatically shortened to `~` for display. Contraction does not occur while the user is editing the tag — only when the name is committed via a command.
- **Filename completion**: Control-F completion now expands `~`, `\$HOME`, and `\$home` prefixes before searching the filesystem, so `~/sr<C-F>` completes correctly.

### 9term

- **Filename completion**: Same Control-F expansion as acme — `~`, `\$HOME`, and `\$home` are expanded before the completion search.

### sam

- **File commands**: All file name arguments to `e`, `r`, `w`, `f`, `B`, and `cd` now expand `~`, `\$HOME`, and `\$home` to the user's home directory. For example, `e ~/.profile` works as expected.

### plumber

- **Environment variable fallback**: The plumber's variable expansion (`\$VAR`) now falls back to Unix environment variables when a name is not defined as a plumbing variable. This allows rules to reference `\$HOME` and similar variables directly.
- **`~/` and `\$home/` plumbing rules**: New rules in `plumb/basic` match file paths beginning with `~/` or `\$home/` and resolve them using `\$homedir`/`\$home` plumbing variables.
- **`initial.plumbing`**: Updated to set `homedir` and `home` plumbing variables to the literal home directory path, enabling the new `basic` rules to resolve home-relative paths.

### Shell session scripts

- `p9p-session.sh.in` and `p9p-session.fish.in` now export `home=\$HOME` so that `plumb \$home/.profile` works correctly from interactive shells running inside plan9port applications.

### Documentation

- `acme(1)`: Documents `~`/`\$HOME`/`\$home` expansion and contraction in window names and Control-F completion.
- `sam(1)`: Documents `~`/`\$HOME`/`\$home` expansion in file name arguments.
- `plumb(7)`: Documents the environment variable fallback in `\$VAR` expansion and the pattern for writing `~/` and `\$home/` plumbing rules.