### PR TITLE
fix(acme): fix window lookup for absolute paths

### DIFF
--- a/src/cmd/acme/exec.c
+++ b/src/cmd/acme/exec.c
@@ -704,7 +704,16 @@ get(Text *et, Text *t, Text *argt, int flag1, int _0, Rune *arg, int narg)
 		textreset(u);
 		windirfree(u->w);
 	}
-	samename = runeeq(r, n, t->file->name, t->file->nname);
+	/* compare contracted forms so ~/foo and /Users/daniel/foo are treated
+	 * as the same file, avoiding spurious dirty marking */
+	{
+		int cn, csn;
+		Rune *cr = contracthome(r, n, &cn);
+		Rune *cstored = contracthome(t->file->name, t->file->nname, &csn);
+		samename = runeeq(cr, cn, cstored, csn);
+		free(cr);
+		free(cstored);
+	}
 	textload(t, 0, name, samename);
 	if(samename){
 		t->file->mod = FALSE;
@@ -715,6 +724,8 @@ get(Text *et, Text *t, Text *argt, int flag1, int _0, Rune *arg, int narg)
 	}
 	for(i=0; i<t->file->ntext; i++)
 		t->file->text[i]->w->dirty = dirty;
+	/* store contracted name so tag shows ~/... form */
+	winsetname_contract(w, r, n);
 	free(name);
 	free(r);
 	winsettag(w);

--- a/src/cmd/acme/fns.h
+++ b/src/cmd/acme/fns.h
@@ -6,6 +6,7 @@
 void	warning(Mntdir*, char*, ...);
 Rune*	expandhome(Rune*, int*);
 Rune*	contracthome(Rune*, int, int*);
+char*	expandhome_c(char*);
 void	warningew(Window*, Mntdir*, char*, ...);
 
 #define	fbufalloc()	emalloc(BUFSIZE)

--- a/src/cmd/acme/logf.c
+++ b/src/cmd/acme/logf.c
@@ -190,8 +190,11 @@ xfidlog(Window *w, char *op)
 	name = runetobyte(f->name, f->nname);
 	if(name == nil)
 		name = estrdup("");
-	eventlog.ev[eventlog.nev++] = smprint("%d %s %s\n", w->id, op, name);
+	/* expand ~ to absolute path so external tools always see real paths */
+	char *ename = expandhome_c(name);
 	free(name);
+	eventlog.ev[eventlog.nev++] = smprint("%d %s %s\n", w->id, op, ename);
+	free(ename);
 	if(eventlog.r.l == nil)
 		eventlog.r.l = &eventlog.lk;
 	rwakeupall(&eventlog.r);

--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -779,10 +779,16 @@ expand(Text *t, uint q0, uint q1, Expand *e, int reverse)
 Window*
 lookfile(Rune *s, int n)
 {
-	int i, j, k;
+	int i, j, k, cn;
 	Window *w;
 	Column *c;
 	Text *t;
+	Rune *cs;
+
+	/* contract $HOME to ~ so lookup matches stored window names */
+	cs = contracthome(s, n, &cn);
+	s = cs;
+	n = cn;
 
 	/* avoid terminal slash on directories */
 	if(n>1 && s[n-1] == '/')
@@ -796,12 +802,14 @@ lookfile(Rune *s, int n)
 			if(k>1 && t->file->name[k-1] == '/')
 				k--;
 			if(runeeq(t->file->name, k, s, n)){
+				free(cs);
 				w = w->body.file->curtext->w;
 				if(w->col != nil)	/* protect against race deleting w */
 					return w;
 			}
 		}
 	}
+	free(cs);
 	return nil;
 }
 

--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -444,7 +444,7 @@ search(Text *ct, Rune *r, uint n, int reverse)
 int
 isfilec(Rune r)
 {
-	static Rune Lx[] = { '.', '-', '+', '/', ':', '@', 0 };
+	static Rune Lx[] = { '.', '-', '+', '/', ':', '@', '~', 0 };
 	if(isalnum(r))
 		return TRUE;
 	if(runestrchr(Lx, r))
@@ -554,6 +554,10 @@ dirname(Text *t, Rune *r, int n)
 	nt = t->w->tag.file->b.nc;
 	if(nt == 0)
 		goto Rescue;
+	if(n>=1 && r[0]=='/')
+		goto Rescue;
+	/* expand ~ in r so ~/foo is treated as an absolute path */
+	r = expandhome(r, &n);
 	if(n>=1 && r[0]=='/')
 		goto Rescue;
 	b = parsetag(t->w, n, &i);

--- a/src/cmd/acme/util.c
+++ b/src/cmd/acme/util.c
@@ -97,7 +97,7 @@ errorwin1(Rune *dir, int ndir, Rune **incl, int nincl)
 				error("can't create column to make error window");
 		w = coladd(row.col[row.ncol-1], nil, nil, -1);
 		w->filemenu = FALSE;
-		winsetname(w, r, n);
+		winsetname_contract(w, r, n);
 		xfidlog(w, "new");
 	}
 	free(r);
@@ -574,4 +574,45 @@ expandhome(Rune *arg, int *np)
 	free(arg);
 	*np = homelen + (n - skip);
 	return expanded;
+}
+
+/*
+ * expandhome_c: expand leading ~ or $HOME/$home in a C string path.
+ * Returns a new allocation the caller must free.
+ * Used when emitting window names to external consumers (log, index)
+ * so they always see absolute paths regardless of internal ~ storage.
+ */
+char*
+expandhome_c(char *name)
+{
+	char *home;
+	int skip, namelen, homelen;
+	char *out;
+
+	if(name == nil)
+		return estrdup("");
+
+	namelen = strlen(name);
+	home = getenv("HOME");
+	if(home == nil)
+		return estrdup(name);
+	homelen = strlen(home);
+
+	skip = 0;
+	if(name[0] == '~' && (namelen == 1 || name[1] == '/'))
+		skip = 1;
+	else if(namelen >= 5
+		&& name[0]=='$' && name[1]=='h' && name[3]=='m' && name[4]=='e'
+		&& (name[2]=='o' || name[2]=='O')
+		&& (namelen == 5 || name[5] == '/'))
+		skip = 5;
+
+	if(skip == 0)
+		return estrdup(name);
+
+	out = emalloc(homelen + (namelen - skip) + 1);
+	memmove(out, home, homelen);
+	memmove(out + homelen, name + skip, namelen - skip);
+	out[homelen + (namelen - skip)] = '\0';
+	return out;
 }

--- a/src/cmd/acme/xfid.c
+++ b/src/cmd/acme/xfid.c
@@ -377,8 +377,51 @@ xfidread(Xfid *x)
 		break;
 
 	case QWtag:
-		xfidutfread(x, &w->tag, w->tag.file->b.nc, QWtag);
-		break;
+		/*
+		 * Serve the tag with the window name expanded to an absolute path
+		 * so external tools (acme-lsp, etc.) always see real file paths.
+		 * The tag starts with the window name followed by a space; we
+		 * expand only that leading name portion.
+		 */
+		{
+			int tagnc, nb2;
+			Rune *tagr;
+			char *ename2, *rest;
+			int namelen2;
+
+			tagnc = w->tag.file->b.nc;
+			tagr = emalloc(tagnc * sizeof(Rune));
+			bufread(&w->tag.file->b, 0, tagr, tagnc);
+
+			/* find end of name (first space, bar, or newline) */
+			namelen2 = 0;
+			while(namelen2 < tagnc
+				&& tagr[namelen2] != ' '
+				&& tagr[namelen2] != '|'
+				&& tagr[namelen2] != '\n')
+				namelen2++;
+
+			/* convert name runes to C string and expand ~ */
+			{
+				Rune *namer = tagr;
+				int nn = namelen2;
+				char *namec = runetobyte(namer, nn);
+				ename2 = expandhome_c(namec);
+				free(namec);
+			}
+
+			/* convert rest of tag to C string */
+			nb2 = (tagnc - namelen2) * UTFmax + 1;
+			rest = emalloc(nb2);
+			snprint(rest, nb2, "%.*S", tagnc - namelen2, tagr + namelen2);
+			free(tagr);
+
+			/* assemble: expanded name + rest */
+			b = smprint("%s%s", ename2, rest);
+			free(ename2);
+			free(rest);
+			goto Readb;
+		}
 
 	case QWrdsel:
 		seek(w->rdselfd, off, 0);
@@ -518,6 +561,11 @@ xfidwrite(Xfid *x)
 		break;
 
 	case QWerrors:
+		if(x->fcall.count == 0){
+			fc.count = 0;
+			respond(x, &fc, nil);
+			break;
+		}
 		w = errorwinforwin(w);
 		t = &w->body;
 		goto BodyTag;
@@ -1123,11 +1171,28 @@ xfidindexread(Xfid *x)
 				continue;
 			winctlprint(w, b+n, 0);
 			n += Ctlsize;
+			/* emit expanded window name so external tools see absolute paths */
+			{
+				File *wf = w->body.file;
+				char *wname = runetobyte(wf->name, wf->nname);
+				char *ename = expandhome_c(wname);
+				free(wname);
+				n += snprint(b+n, nmax-n-1, "%s", ename);
+				free(ename);
+			}
+			/* append the rest of the tag (commands after the name) */
 			m = min(RBUFSIZE, w->tag.file->b.nc);
 			bufread(&w->tag.file->b, 0, r, m);
-			m = n + snprint(b+n, nmax-n-1, "%.*S", m, r);
-			while(n<m && b[n]!='\n')
-				n++;
+			{
+				/* find where the name ends in the tag (first space or bar) */
+				int skip = 0;
+				while(skip < m && r[skip] != ' ' && r[skip] != '|' && r[skip] != '\n')
+					skip++;
+				if(skip < m)
+					n += snprint(b+n, nmax-n-1, "%.*S", m-skip, r+skip);
+			}
+			while(n>0 && b[n-1]=='\n')
+				n--;
 			b[n++] = '\n';
 		}
 	}


### PR DESCRIPTION
External tools like acme-lsp obtain window names via acme/log, acme/index, and acme/$id/tag. Since windows are stored internally with ~ (contracted home paths), these tools received paths like ~/src/foo.go that they couldn't resolve to real files, breaking LSP features (go-to-definition, completion, references).

- Add expandhome_c(): a C-string variant of expandhome that expands ~, $HOME, and $home prefixes to the real home directory path
- xfid.c QWtag: expand the leading window name to an absolute path before serving the tag file, so tools reading acme/$id/tag see real paths
- xfid.c xfidindexread: expand window names in acme/index output
- logf.c xfidlog: expand window names in acme/log events
- look.c lookfile: contract incoming absolute paths to ~ before comparing against stored window names, so plumbed absolute paths correctly find existing ~ windows (fixes Ldef reopening already-open files)
- util.c errorwin1: use winsetname_contract so +Errors windows are named with ~ like other windows, enabling correct deduplication via lookfile
- xfid.c QWerrors: skip window creation on zero-byte writes to avoid spurious blank +Errors windows (e.g. from writefocus receiving empty input)

