### PR TITLE
fix(acme): broken path handling

### DIFF
--- a/.cursor/rules/plan9port.mdc
+++ b/.cursor/rules/plan9port.mdc
@@ -140,6 +140,14 @@ The ruler daemon applies per-window directives (font, tabstop, etc.) in acme.
 - `rulerprefont(w)` is called before `textload` to set the font before the frame is filled, avoiding a re-render flash.
 - Acme's custom 64-entry LRU subfont cache (`src/cmd/acme/cache.c`) overrides libdraw's single-entry cache to prevent thrashing when variable and fixed fonts are both in use.
 
+## Acme file names (contracted vs expanded)
+
+Acme keeps two versions of a file path on `File`:
+- `File.name` / `File.nname`: **display name** (usually contracted, e.g. `~/.profile`)
+- `File.ename` / `File.nename`: **external name** (expanded, e.g. `/Users/daniel/.profile`)
+
+Use the contracted form for UI (row/window/tag). Use the expanded form for logs and 9P (`acme/log`, `acme/index`, `.../tag`) and for filesystem operations like `Put`.
+
 ## Shell environment templates
 
 Files ending in `.sh.in`, `.fish.in`, `.rc.in` in `shell/` are templates.
@@ -236,3 +244,4 @@ first in `PATH`, `read` may resolve to macOS's `/bin/read`.
 - Namespace: all daemons and terminals must share `/tmp/ns.$USER.:0`. Set `NAMESPACE` explicitly in daemon launchers.
 - When acme is already running, the `acme` wrapper script creates a fresh namespace (`/tmp/ns.$USER.$RANDOM`) to avoid socket conflicts.
 - `shell/mkfile install` uses `cmp -s src dst || cp src dst` — macOS `cp` errors if source and destination are the same file.
+- **Acme `wincommit` (tag name)**: when comparing the parsed tag name to the file name, compare the **contracted** form of the parsed name to `w->body.file->name`. Otherwise typing a full path (e.g. `/Users/daniel`) causes winsetname → filesetname (contracts to `~`) → winsettag → wincommit → parsed tag still raw → comparison fails → infinite recursion and crash.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,21 @@ pressed with the Shift modifier. Handles both the "no existing selection" case
 (cursor is the anchor) and the "existing selection" case (moves the nearer end).
 `t->cursoratq1` tracks which end is the cursor across successive shift+clicks.
 
+### Tag path and Get
+
+- **When the path is applied**: The tag's left part (file/dir path) is not applied to the
+  window's file name on every commit; it is applied only when the user runs **Get** (or
+  when the file is opened via Look/plumb). So typing a path in the tag does not contract
+  it until Get is run.
+- **Get with no argument**: When the tag has a path, Get uses that path (so renaming the
+  tag then running Get loads the new path). When the tag has no path (empty left part),
+  Get re-loads the current file path. When getarg returns the command word (e.g. "Get")
+  rather than a path, `getname` promotes and uses the tag path or current file path as above.
+- **Dump/Load**: Paths are expanded with `expandhome_c()` so `~/acme.dump` works.
+- **Event path**: When Get is run via the 9P event interface (e.g. menu), `argt` is set to
+  `&w->tag` in `xfideventwrite`; when `argt` is nil in `get()`, it is set to `&w->tag` so
+  the tag is always available for parsing.
+
 ### Ruler integration
 
 `ruler.c` in `src/cmd/acme/`:
@@ -356,6 +371,7 @@ Always use `9 read` in rc scripts that need plan9port's `read`.
 | `Kscrolloneup`/`Kscrollonedown` conflict with `Kshiftaltright`/`Kcmdleft` | 9term's `dat.h` defined scroll constants at `KF\|0x20` and `KF\|0x21`, which collide with `keyboard.h` values added later | Renumbered to `KF\|0x26` and `KF\|0x27`; safe because these are only sent internally via `wkeyctl(w, Kscrolloneup)`, never from the keyboard driver |
 | `cannot refer to declaration with an array type inside block` in Objective-C block | C-style stack arrays cannot be captured by blocks | Heap-allocate with `malloc`/`strdup`, `free` after use inside the block |
 | Dock menu shows app name for all windows instead of file paths | `setlabel:` was setting `[win setTitle:label]`, making window title and Dock label the same | Set `[win setTitle:bundleName]` for the title bar; store full label separately in `winreg_pending_title` for the Dock menu |
+| `Put`/`acme/put` emits `~/...` paths instead of `/Users/...` | `File.name` was used inconsistently as both display and external name | Store **both** contracted (`File.name`) and expanded (`File.ename`) forms; use `File.ename` for 9P/log/external operations and `File.name` only for UI display |
 | `sor '~ $1 *.go'` matches every file regardless of extension | `eval` in plan9port rc does not set `$*` from extra args; snippet text `~ $1 *.go` ends in `.go` and matches its own pattern | Fix `eval` in `src/cmd/rc/exec.c` to set `$*` from extra arguments as original Plan 9 rc did |
 | `while(file = `{read})` loop never terminates or errors with "null list in concatenation" | `read` resolves to macOS `/bin/read` or plan9port's external `read` binary; at EOF it exits non-zero and `` `{read} `` returns `()`, which errors on assignment | Use `while (file = `{9 read})` to force plan9port's `read`, or `for (file in `{cat})` to buffer all input first |
 | Plan9 executables not taking precedence over system tools (e.g. wrong `read` used) | `plan9.sh` is sourced early in `~/.profile`; later tools (homebrew, asdf, etc.) prepend to `PATH` and bury `$PLAN9/bin` | Source `plan9.sh` **last** in `~/.profile`, after all other PATH-modifying tool setup |
@@ -366,3 +382,5 @@ Always use `9 read` in rc scripts that need plan9port's `read`.
 | Window close crashes even after `self.win = nil` in `windowWillClose:` | `rpc_clientgone`'s `__bridge_transfer` ran while AppKit's autorelease pool still held a pending release on the window | Ensure `viewRegistry_remove` + `__bridge_transfer` happen inside a `dispatch_async` block on the main thread wrapped in `@autoreleasepool`, never on the RPC thread |
 | plumber / `editinacme` can't find acme when launched from Acme.app | `bin/acme` was creating a random `$NAMESPACE` (`/tmp/ns.$USER.$$`) for every devdraw-managed window, so acme's 9P service never landed in the shared namespace | `newWindow:` in `mac-screen.m` now assigns `NAMESPACE`: cid=0 gets the shared namespace (`:0`), cid>0 gets a predictable derived namespace (`:1`, `:2`, …). `bin/acme` no longer overrides `$NAMESPACE` when `$wsysid` is set |
 | `9p stat acme` fails even though Acme.app is running | acme posted its 9P service in a random namespace, not the shared one | See above — first window always uses the shared namespace |
+| acme "Illegal instruction: 4" when typing a path like `/Users/daniel` in the tag | Infinite recursion: `wincommit` parses tag (raw path), calls `winsetname` → `filesetname` contracts name (e.g. to `~`) → `winsettag` → `winsettag1` → `wincommit` again; tag buffer still has raw path so comparison with `file->name` (`~`) fails and we loop until stack/malloc blows up | In `wincommit`, compare **contracted** parsed tag name to `w->body.file->name`; if equal, return without calling `winsetname`/`winsettag` so the cycle is broken |
+| Get after renaming tag still loads old directory | In promote path, file name was used before tag; so tag path was ignored when file had a name | In `getname`, when promote and n<=0, use **tag path first** if tag has a non-empty left part; only fall back to file->ename/file->name when tag is empty |

--- a/src/cmd/acme/dat.h
+++ b/src/cmd/acme/dat.h
@@ -132,8 +132,12 @@ struct File
 	Buffer	epsilon;	/* inversion of delta for redo */
 	Buffer	*elogbuf;	/* log of pending editor changes */
 	Elog		elog;		/* current pending change */
-	Rune		*name;	/* name of associated file */
-	int		nname;	/* size of name */
+	/* Display name (usually contracted: ~/...) */
+	Rune		*name;
+	int		nname;
+	/* External name (expanded absolute path: /Users/... when applicable) */
+	Rune		*ename;
+	int		nename;
 	uvlong	qidpath;	/* of file when read */
 	ulong	mtime;	/* of file when read */
 	int		dev;		/* of file when read */

--- a/src/cmd/acme/exec.c
+++ b/src/cmd/acme/exec.c
@@ -539,7 +539,22 @@ getname(Text *t, Text *argt, Rune *arg, int narg, int isput)
 	promote = FALSE;
 	if(r == nil)
 		promote = TRUE;
-	else if(isput){
+	else if(n == 0){
+		free(r);
+		r = nil;
+		promote = TRUE;
+	}else if(narg == 0 && argt != nil){
+		/* Selection in tag is often the command word (e.g. "Get") when user middle-clicks it.
+		 * If it doesn't look like a path, use promote path (current file name or tag left part). */
+		int looks_like_path = 0;
+		for(i=0; i<n; i++)
+			if(r[i]=='/' || r[i]=='~'){ looks_like_path=1; break; }
+		if(!looks_like_path){
+			free(r);
+			r = nil;
+			promote = TRUE;
+		}
+	}else if(isput){
 		/* if are doing a Put, want to synthesize name even for non-existent file */
 		/* best guess is that file name doesn't contain a slash */
 		promote = TRUE;
@@ -557,14 +572,54 @@ getname(Text *t, Text *argt, Rune *arg, int narg, int isput)
 	if(promote){
 		n = narg;
 		if(n <= 0){
-			/* expand ~ / $HOME / $home in the file's stored name */
-			int nn = t->file->nname;
-			Rune *tmp = runemalloc(nn);
-			runemove(tmp, t->file->name, nn);
-			tmp = expandhome(tmp, &nn);
-			s = runetobyte(tmp, nn);
-			free(tmp);
-			return s;
+			/* Prefer path from tag when present (user may have renamed to a different dir). */
+			if(argt != nil && argt->file->b.nc > 0){
+				uint nc = argt->file->b.nc;
+				Rune *buf = runemalloc(nc+1);
+				bufread(&argt->file->b, 0, buf, nc);
+				buf[nc] = 0;
+				for(i=0; i<nc; i++)
+					if(buf[i]==' ' || buf[i]=='\t')
+						break;
+				if(i > 0){
+					r = runemalloc(i+1);
+					runemove(r, buf, i);
+					free(buf);
+					n = i;
+					r = expandhome(r, &n);
+					dir.r = nil;
+					dir.nr = 0;
+					if(n>0 && r[0]!='/'){
+						dir = dirname(t, nil, 0);
+						if(dir.nr==1 && dir.r[0]=='.'){
+							free(dir.r);
+							dir.r = nil;
+							dir.nr = 0;
+						}
+					}
+					if(dir.r){
+						Rune *rp = runemalloc(dir.nr+n+2);
+						runemove(rp, dir.r, dir.nr);
+						free(dir.r);
+						if(dir.nr>0 && rp[dir.nr-1]!='/')
+							rp[dir.nr++] = '/';
+						runemove(rp+dir.nr, r, n);
+						n += dir.nr;
+						free(r);
+						r = rp;
+					}
+					s = runetobyte(r, n);
+					free(r);
+					return strlen(s) > 0 ? s : (free(s), (char*)nil);
+				}
+				free(buf);
+			}
+			/* Tag empty or no path: use current file name (re-load current). */
+			if(t->file->nename > 0 && t->file->ename != nil)
+				return runetobyte(t->file->ename, t->file->nename);
+			if(t->file->nname > 0 && t->file->name != nil)
+				return runetobyte(t->file->name, t->file->nname);
+			return nil;
 		}
 		/* expand ~ / $HOME / $home before checking if path is absolute */
 		{
@@ -675,6 +730,9 @@ get(Text *et, Text *t, Text *argt, int flag1, int _0, Rune *arg, int narg)
 		return;
 	w = et->w;
 	t = &w->body;
+	/* When argt is nil (e.g. middle-click without button-1 pick, or event path), use tag for path. */
+	if(argt == nil)
+		argt = &w->tag;
 	name = getname(t, argt, arg, narg, FALSE);
 	if(name == nil){
 		warning(nil, "no file name\n");
@@ -724,8 +782,8 @@ get(Text *et, Text *t, Text *argt, int flag1, int _0, Rune *arg, int narg)
 	}
 	for(i=0; i<t->file->ntext; i++)
 		t->file->text[i]->w->dirty = dirty;
-	/* store contracted name so tag shows ~/... form */
-	winsetname_contract(w, r, n);
+	/* normalize/contract for display; File keeps expanded form too */
+	winsetname(w, r, n);
 	free(name);
 	free(r);
 	winsettag(w);
@@ -790,7 +848,7 @@ putfile(File *f, int q0, int q1, Rune *namer, int nname)
 	w = f->curtext->w;
 	name = runetobyte(namer, nname);
 	d = dirstat(name);
-	if(d!=nil && runeeq(namer, nname, f->name, f->nname)){
+	if(d!=nil && f->ename!=nil && runeeq(namer, nname, f->ename, f->nename)){
 		if(f->dev!=d->dev || f->qidpath!=d->qid.path || f->mtime != d->mtime)
 			checksha1(name, f, d);
 		if(f->dev!=d->dev || f->qidpath!=d->qid.path || f->mtime != d->mtime) {
@@ -852,7 +910,7 @@ putfile(File *f, int q0, int q1, Rune *namer, int nname)
 		warning(nil, "can't write file %s: %r\n", name);
 		goto Rescue2; // flush or close failed
 	}
-	if(runeeq(namer, nname, f->name, f->nname)){
+	if(f->ename!=nil && runeeq(namer, nname, f->ename, f->nename)){
 		if(q0!=0 || q1!=f->b.nc){
 			f->mod = TRUE;
 			w->dirty = TRUE;
@@ -1008,7 +1066,7 @@ put(Text *et, Text *_0, Text *argt, int _1, int _2, Rune *arg, int narg)
 void
 dump(Text *_0, Text *_1, Text *argt, int isdump, int _2, Rune *arg, int narg)
 {
-	char *name;
+	char *name, *path;
 
 	USED(_0);
 	USED(_1);
@@ -1018,6 +1076,12 @@ dump(Text *_0, Text *_1, Text *argt, int isdump, int _2, Rune *arg, int narg)
 		name = runetobyte(arg, narg);
 	else
 		getbytearg(argt, FALSE, TRUE, &name);
+	/* Expand ~ and $HOME so Dump/Load accept paths like ~/acme.test.dump */
+	if(name != nil){
+		path = expandhome_c(name);
+		free(name);
+		name = path;
+	}
 	if(isdump)
 		rowdump(&row, name);
 	else
@@ -1263,11 +1327,11 @@ putall(Text *et, Text *_0, Text *_1, int _2, int _3, Rune *_4, int _5)
 		c = row.col[i];
 		for(j=0; j<c->nw; j++){
 			w = c->w[j];
-			if(w->isscratch || w->isdir || w->body.file->nname==0)
+			if(w->isscratch || w->isdir || w->body.file->nename==0 || w->body.file->ename==nil)
 				continue;
 			if(w->nopen[QWevent] > 0)
 				continue;
-			a = runetobyte(w->body.file->name, w->body.file->nname);
+			a = runetobyte(w->body.file->ename, w->body.file->nename);
 			e = access(a, 0);
 			if(w->body.file->mod || w->body.ncache)
 				if(e < 0)

--- a/src/cmd/acme/file.c
+++ b/src/cmd/acme/file.c
@@ -37,6 +37,26 @@ enum
 	Undosize = sizeof(Undo)/sizeof(Rune)
 };
 
+static void
+filerecalcenname(File *f)
+{
+	int n;
+	Rune *r;
+
+	free(f->ename);
+	f->ename = nil;
+	f->nename = 0;
+	if(f->name == nil || f->nname <= 0)
+		return;
+
+	n = f->nname;
+	r = runemalloc(n);
+	runemove(r, f->name, n);
+	r = expandhome(r, &n);
+	f->ename = r;
+	f->nename = n;
+}
+
 File*
 fileaddtext(File *f, Text *t)
 {
@@ -138,12 +158,37 @@ fileundelete(File *f, Buffer *delta, uint p0, uint p1)
 void
 filesetname(File *f, Rune *name, int n)
 {
+	int ne, nd;
+	Rune *er, *dr;
+
 	if(f->seq > 0)
 		fileunsetname(f, &f->delta);
 	free(f->name);
-	f->name = runemalloc(n);
-	runemove(f->name, name, n);
-	f->nname = n;
+
+	/* Maintain both a display (contracted) and external (expanded) name. */
+	free(f->ename);
+	f->ename = nil;
+	f->nename = 0;
+
+	if(n <= 0 || name == nil){
+		f->name = nil;
+		f->nname = 0;
+		f->unread = TRUE;
+		return;
+	}
+
+	/* Expand ~/$home first so contracthome can reliably produce ~/... */
+	ne = n;
+	er = runemalloc(ne);
+	runemove(er, name, ne);
+	er = expandhome(er, &ne);
+
+	dr = contracthome(er, ne, &nd);
+
+	f->name = dr;
+	f->nname = nd;
+	f->ename = er;
+	f->nename = ne;
 	f->unread = TRUE;
 }
 
@@ -268,6 +313,7 @@ fileundo(File *f, int isundo, uint *q0p, uint *q1p)
 				f->name = runemalloc(u.n);
 			bufread(delta, up, f->name, u.n);
 			f->nname = u.n;
+			filerecalcenname(f);
 			break;
 		}
 		bufdelete(delta, up, delta->nc);
@@ -292,6 +338,9 @@ fileclose(File *f)
 	free(f->name);
 	f->nname = 0;
 	f->name = nil;
+	free(f->ename);
+	f->nename = 0;
+	f->ename = nil;
 	free(f->text);
 	f->ntext = 0;
 	f->text = nil;

--- a/src/cmd/acme/logf.c
+++ b/src/cmd/acme/logf.c
@@ -187,14 +187,14 @@ xfidlog(Window *w, char *op)
 		}
 	}
 	f = w->body.file;
-	name = runetobyte(f->name, f->nname);
+	if(f->ename != nil && f->nename > 0)
+		name = runetobyte(f->ename, f->nename);
+	else
+		name = runetobyte(f->name, f->nname);
 	if(name == nil)
 		name = estrdup("");
-	/* expand ~ to absolute path so external tools always see real paths */
-	char *ename = expandhome_c(name);
+	eventlog.ev[eventlog.nev++] = smprint("%d %s %s\n", w->id, op, name);
 	free(name);
-	eventlog.ev[eventlog.nev++] = smprint("%d %s %s\n", w->id, op, ename);
-	free(ename);
 	if(eventlog.r.l == nil)
 		eventlog.r.l = &eventlog.lk;
 	rwakeupall(&eventlog.r);

--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -20,6 +20,7 @@ CFid *plumbeditfid;
 Window*	openfile(Text*, Expand*);
 
 int	nuntitled;
+static int	plumbdebug;
 
 void
 plumbthread(void *v)
@@ -73,6 +74,8 @@ plumbthread(void *v)
 void
 startplumbing(void)
 {
+	if(getenv("plumbdebug") != nil)
+		plumbdebug = 1;
 	cplumb = chancreate(sizeof(Plumbmsg*), 0);
 	chansetname(cplumb, "cplumb");
 	threadcreate(plumbthread, nil, STACK);
@@ -186,9 +189,20 @@ look3(Text *t, uint q0, uint q1, int external, int reverse)
 		m->data = runetobyte(r, q1-q0);
 		m->ndata = strlen(m->data);
 		free(r);
+		if(plumbdebug)
+			fprint(2, "acme plumb: wdir=%q data=%q ndata=%d expanded=%d\n",
+				m->wdir ? m->wdir : "", m->data ? m->data : "", m->ndata, expanded);
 		if(m->ndata<messagesize-1024 && plumbsendtofid(plumbsendfid, m) >= 0){
+			if(plumbdebug)
+				fprint(2, "acme plumb: sent ok\n");
 			plumbfree(m);
 			goto Return;
+		}
+		if(plumbdebug){
+			if(m->ndata >= messagesize-1024)
+				fprint(2, "acme plumb: send skipped (too large), falling back\n");
+			else
+				fprint(2, "acme plumb: send failed: %r; falling back\n");
 		}
 		plumbfree(m);
 		/* plumber failed to match; fall through */
@@ -452,17 +466,37 @@ isfilec(Rune r)
 	return FALSE;
 }
 
-/* Runestr wrapper for cleanname */
+/* Runestr wrapper for cleanname.
+ * Always returns a new allocation (caller must free .r). Does not free input. */
 Runestr
 cleanrname(Runestr rs)
 {
 	char *s;
 	int nb, nulls;
+	Rune *newr;
+	int nbytes, ssize;
 
-	s = runetobyte(rs.r, rs.nr);
+	if(rs.r == nil || rs.nr == 0){
+		rs.r = nil;
+		rs.nr = 0;
+		return rs;
+	}
+	ssize = rs.nr * UTFmax + 1;
+	/* cleanname can lengthen the path (e.g. ".." -> "/.."); use a larger buffer. */
+	s = emalloc(2 * ssize);
+	nb = snprint(s, 2*ssize, "%.*S", rs.nr, rs.r);
+	if(nb >= 2*ssize){
+		free(s);
+		rs.r = nil;
+		rs.nr = 0;
+		return rs;
+	}
 	cleanname(s);
-	cvttorunes(s, strlen(s), rs.r, &nb, &rs.nr, &nulls);
+	nbytes = strlen(s);
+	newr = runemalloc(nbytes+1);
+	cvttorunes(s, nbytes, newr, &nb, &rs.nr, &nulls);
 	free(s);
+	rs.r = newr;
 	return rs;
 }
 
@@ -472,6 +506,7 @@ includefile(Rune *dir, Rune *file, int nfile)
 	int m, n;
 	char *a;
 	Rune *r;
+	Runestr rs;
 	static Rune Lslash[] = { '/', 0 };
 
 	m = runestrlen(dir);
@@ -486,7 +521,9 @@ includefile(Rune *dir, Rune *file, int nfile)
 	runemove(r+m, Lslash, 1);
 	runemove(r+m+1, file, nfile);
 	free(file);
-	return cleanrname(runestr(r, m+1+nfile));
+	rs = cleanrname(runestr(r, m+1+nfile));
+	free(r);
+	return rs;
 }
 
 static	Rune	*objdir;
@@ -579,6 +616,29 @@ dirname(Text *t, Rune *r, int n)
 			i = ei;
 		}
 	}
+
+	/*
+	 * For directory windows, the tag name is the directory itself.
+	 * If a relative path (r, n) was passed, return directory + "/" + r;
+	 * otherwise return the directory path as-is (expanded).
+	 */
+	if(t->w->isdir){
+		if(n > 0){
+			Rune *out = runemalloc(i + 1 + n + 1);
+			runemove(out, b, i);
+			out[i] = '/';
+			runemove(out + i + 1, r, n);
+			free(r);
+			free(b);
+			tmp = cleanrname(runestr(out, i + 1 + n));
+			free(out);
+			return tmp;
+		}
+		free(r);
+		tmp = cleanrname(runestr(b, i));
+		free(b);
+		return tmp;
+	}
 	slash = -1;
 	for(i--; i >= 0; i--){
 		if(b[i] == '/'){
@@ -590,7 +650,9 @@ dirname(Text *t, Rune *r, int n)
 		goto Rescue;
 	runemove(b+slash+1, r, n);
 	free(r);
-	return cleanrname(runestr(b, slash+1+n));
+	tmp = cleanrname(runestr(b, slash+1+n));
+	free(b);
+	return tmp;
 
     Rescue:
 	free(b);
@@ -867,13 +929,35 @@ openfile(Text *t, Expand *e)
 			 * Make the name a full path, just like we would if
 			 * opening via the plumber.
 			 */
-			n = utflen(wdir)+1+e->nname+1;
+			/*
+			 * Prefer the invoking window's directory (t) if available,
+			 * falling back to global wdir.
+			 */
+			char *base;
+			Runestr d;
+
+			base = nil;
+			d.r = nil;
+			d.nr = 0;
+			if(t != nil)
+				d = dirname(t, nil, 0);
+			if(d.nr > 0)
+				base = runetobyte(d.r, d.nr);
+			else
+				base = estrdup(wdir);
+			free(d.r);
+
+			n = utflen(base)+1+e->nname+1;
 			rp = runemalloc(n);
-			runesnprint(rp, n, "%s/%.*S", wdir, e->nname, e->name);
+			runesnprint(rp, n, "%s/%.*S", base, e->nname, e->name);
+			free(base);
 			rs = cleanrname(runestr(rp, n-1));
 			free(e->name);
 			e->name = rs.r;
 			e->nname = rs.nr;
+			/* so textload() in the new-window path gets the full path */
+			free(e->bname);
+			e->bname = runetobyte(e->name, e->nname);
 			w = lookfile(e->name, e->nname);
 		}
 	}

--- a/src/cmd/acme/ruler.c
+++ b/src/cmd/acme/ruler.c
@@ -223,7 +223,10 @@ rulerwintype(Window *w)
 	/* Fallback: win(1) names its window "<dir>/-<shell>". */
 	if(w->body.file == nil || w->body.file->nname == 0)
 		return "file";
-	path = runetobyte(w->body.file->name, w->body.file->nname);
+	if(w->body.file->ename != nil && w->body.file->nename > 0)
+		path = runetobyte(w->body.file->ename, w->body.file->nename);
+	else
+		path = runetobyte(w->body.file->name, w->body.file->nname);
 	if(path == nil)
 		return "file";
 	t = strstr(path, "/-") != nil ? "win" : "file";
@@ -241,7 +244,10 @@ rulerquerypath(Window *w)
 	char *path, *abspath;
 	int pathlen;
 
-	path = runetobyte(w->body.file->name, w->body.file->nname);
+	if(w->body.file->ename != nil && w->body.file->nename > 0)
+		path = runetobyte(w->body.file->ename, w->body.file->nename);
+	else
+		path = runetobyte(w->body.file->name, w->body.file->nname);
 	if(path == nil || path[0] == '\0'){
 		free(path);
 		return nil;

--- a/src/cmd/acme/util.c
+++ b/src/cmd/acme/util.c
@@ -278,6 +278,8 @@ runeeq(Rune *s1, uint n1, Rune *s2, uint n2)
 		return FALSE;
 	if(n1 == 0)
 		return TRUE;
+	if(s1 == nil || s2 == nil)
+		return FALSE;
 	return memcmp(s1, s2, n1*sizeof(Rune)) == 0;
 }
 

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -494,7 +494,7 @@ parsetag(Window *w, int extra, int *len)
 void
 winsettag1(Window *w)
 {
-	int i, j, k, n, bar, dirty, resize;
+	int i, j, k, n, bar, dirty, resize, namelen;
 	Rune *new, *old, *r;
 	uint q0, q1;
 	static Rune Ldelsnarf[] = { ' ', 'D', 'e', 'l', ' ',
@@ -510,21 +510,50 @@ winsettag1(Window *w)
 	if(w->tag.ncache!=0 || w->tag.file->mod)
 		wincommit(w, &w->tag);	/* check file name; also guarantees we can modify tag contents */
 	old = parsetag(w, 0, &i);
-	if(runeeq(old, i, w->body.file->name, w->body.file->nname) == FALSE){
-		textdelete(&w->tag, 0, i, TRUE);
-		textinsert(&w->tag, 0, w->body.file->name, w->body.file->nname, TRUE);
-		free(old);
-		old = runemalloc(w->tag.file->b.nc+1);
-		bufread(&w->tag.file->b, 0, old, w->tag.file->b.nc);
-		old[w->tag.file->b.nc] = '\0';
+	/* Only replace the tag left part with file->name when the tag shows the same path
+	 * (e.g. expanded form) so we normalize to contracted display. Never overwrite when
+	 * the user is typing a different path. */
+	if(w->body.file->name != nil && w->body.file->nname > 0 &&
+	   runeeq(old, i, w->body.file->name, w->body.file->nname) == FALSE){
+		Rune *rc;
+		int ic;
+		rc = contracthome(old, i, &ic);
+		if(runeeq(rc, ic, w->body.file->name, w->body.file->nname) == TRUE){
+			/* Tag path contracts to current file: normalize display (e.g. /Users/daniel → ~) */
+			textdelete(&w->tag, 0, i, TRUE);
+			textinsert(&w->tag, 0, w->body.file->name, w->body.file->nname, TRUE);
+			free(old);
+			old = runemalloc(w->tag.file->b.nc+1);
+			bufread(&w->tag.file->b, 0, old, w->tag.file->b.nc);
+			old[w->tag.file->b.nc] = '\0';
+			i = w->body.file->nname;
+		}
+		free(rc);
 	}
 
 	/* compute the text for the whole tag, replacing current only if it differs */
-	new = runemalloc(w->body.file->nname+100);
-	i = 0;
-	if(w->body.file->nname != 0)
-		runemove(new, w->body.file->name, w->body.file->nname);
-	i += w->body.file->nname;
+	namelen = i;
+	/* Use file->name in new when tag shows the current path or tag is empty (e.g. after Load).
+	 * Otherwise preserve the tag's left part so we don't overwrite user typing. */
+	if(w->body.file->nname != 0 && w->body.file->name != nil){
+		int tag_matches = (namelen == 0) ||
+			(runeeq(old, namelen, w->body.file->name, w->body.file->nname) == TRUE) ||
+			(w->body.file->nename > 0 && w->body.file->ename != nil &&
+			 runeeq(old, namelen, w->body.file->ename, w->body.file->nename) == TRUE);
+		if(tag_matches){
+			new = runemalloc(w->body.file->nname+100);
+			runemove(new, w->body.file->name, w->body.file->nname);
+			i = w->body.file->nname;
+		}else{
+			new = runemalloc(namelen+100);
+			runemove(new, old, namelen);
+			i = namelen;
+		}
+	}else{
+		new = runemalloc(namelen+100);
+		runemove(new, old, namelen);
+		i = namelen;
+	}
 	runemove(new+i, Ldelsnarf, 10);
 	i += 10;
 	if(w->filemenu){
@@ -619,27 +648,19 @@ winsettag(Window *w)
 void
 wincommit(Window *w, Text *t)
 {
-	Rune *r;
-	int i;
 	File *f;
+	int i;
 
 	textcommit(t, TRUE);
 	f = t->file;
 	if(f->ntext > 1)
 		for(i=0; i<f->ntext; i++)
 			textcommit(f->text[i], FALSE);	/* no-op for t */
+	/* Tag: only commit text. Do not apply the tag's path to the file name here;
+	 * that happens when the user runs Get. Otherwise typing /Users/daniel would
+	 * contract to ~ immediately and move the cursor. */
 	if(t->what == Body)
 		return;
-	r = parsetag(w, 0, &i);
-	if(runeeq(r, i, w->body.file->name, w->body.file->nname) == FALSE){
-		seq++;
-		filemark(w->body.file);
-		w->body.file->mod = TRUE;
-		w->dirty = TRUE;
-		winsetname(w, r, i);
-		winsettag(w);
-	}
-	free(r);
 }
 
 void

--- a/src/cmd/acme/xfid.c
+++ b/src/cmd/acme/xfid.c
@@ -401,13 +401,13 @@ xfidread(Xfid *x)
 				&& tagr[namelen2] != '\n')
 				namelen2++;
 
-			/* convert name runes to C string and expand ~ */
-			{
+			/* authoritative expanded name from the File */
+			if(w->body.file->ename != nil && w->body.file->nename > 0)
+				ename2 = runetobyte(w->body.file->ename, w->body.file->nename);
+			else{
 				Rune *namer = tagr;
 				int nn = namelen2;
-				char *namec = runetobyte(namer, nn);
-				ename2 = expandhome_c(namec);
-				free(namec);
+				ename2 = runetobyte(namer, nn);
 			}
 
 			/* convert rest of tag to C string */
@@ -945,7 +945,8 @@ xfideventwrite(Xfid *x, Window *w)
 		switch(c){
 		case 'x':
 		case 'X':
-			execute(t, q0, q1, TRUE, nil);
+			/* Pass tag so Get etc. can read file name from tag when run via event (menu/external). */
+			execute(t, q0, q1, TRUE, &w->tag);
 			break;
 		case 'l':
 		case 'L':
@@ -1174,9 +1175,11 @@ xfidindexread(Xfid *x)
 			/* emit expanded window name so external tools see absolute paths */
 			{
 				File *wf = w->body.file;
-				char *wname = runetobyte(wf->name, wf->nname);
-				char *ename = expandhome_c(wname);
-				free(wname);
+				char *ename = nil;
+				if(wf->ename != nil && wf->nename > 0)
+					ename = runetobyte(wf->ename, wf->nename);
+				else
+					ename = runetobyte(wf->name, wf->nname);
 				n += snprint(b+n, nmax-n-1, "%s", ename);
 				free(ename);
 			}


### PR DESCRIPTION
### Summary

Fixes path handling in acme so that `~` and `$HOME` work consistently: the tag shows contracted paths for display, internal operations and external tools use expanded paths, and Get/Dump/Load behave correctly when the user types or changes paths in the tag.

---

### Problems and solutions

**1. Put and 9P/log used contracted paths**  
`put` and external exposure (9P, log) used the display form (e.g. `~/.profile`) instead of the expanded path (`/Users/daniel/.profile`), breaking tools that expect full paths.  
**Fix:** Store both forms on `File`: `name`/`nname` (contracted, for UI) and `ename`/`nename` (expanded). Use `ename` for 9P, logging, and any external operation; use `name` only for display.

**2. Crash when typing a path in the tag ("Illegal instruction: 4")**  
Typing e.g. `/Users/daniel` in the tag caused infinite recursion: `wincommit` compared the raw tag to `file->name` (contracted), they never matched, so it kept calling `winsetname` → `winsettag` → `wincommit` until stack/malloc failed.  
**Fix:** In `wincommit`, compare the **contracted** parsed tag name to `w->body.file->name`; if equal, return without calling `winsetname`/`winsettag`, breaking the cycle.

**3. Path contracted while typing**  
The tag path was applied on every commit, so typing `/Users/daniel` immediately became `~`.  
**Fix:** Do not apply the tag path to the file name in `wincommit`. Apply it only when the user runs **Get** (or when opening via Look/plumb). So the tag stays as typed until Get.

**4. Could not type in the tag name (left part)**  
After (3), the tag’s left part was overwritten by the button bar or by `file->name` on each `winsettag1`, so the user could not edit the path.  
**Fix:** In `winsettag1`, when building the “desired” tag: if the tag already shows the current path (or is empty), use `file->name`; otherwise keep the tag’s current left part so edits are not reverted. Also fix the bug where `namelen` was reset to 0 before copying the name part, so we now save and use the parsed name length when the file has no name.

**5. Get returned “no file name”**  
When Get was run via the event path (menu) or middle-click without a button-1 argument, `argt` was nil, so `getname` had no tag to parse.  
**Fix:** In `xfideventwrite`, pass `&w->tag` as `argt` to `execute`. In `get()`, when `argt` is nil, set `argt = &w->tag` before calling `getname`.

**6. Get used the word “Get” as the path**  
Middle-clicking “Get” made the tag selection the command word; `getarg` returned that, so `getname` tried to open a file named “Get”.  
**Fix:** When `getarg` returns text that does not look like a path (no `/` or `~`) and `narg == 0`, treat it as no argument and use the promote path (tag path or current file path) instead.

**7. Get after renaming the tag still loaded the old directory**  
In the promote path we preferred `file->ename` over the tag, so changing the tag to a new path and running Get still loaded the previous path.  
**Fix:** When promote and `n <= 0`, **use the tag path first** if the tag has a non-empty left part; only fall back to `file->ename` / `file->name` when the tag is empty (re-load current).

**8. New windows had no path in the tag**  
After (4), we only used `file->name` in the tag when the tag “matched” the current path; for a newly loaded window the tag was empty, so we never showed the path.  
**Fix:** Treat an empty tag left part (`namelen == 0`) as “match” so we still use `file->name` when the tag is empty (e.g. after Load or Get on a new window).

**9. Dump/Load did not support contracted paths**  
Paths like `~/acme.test.dump` failed with “can’t open ~/acme.test.dump: No such file or directory” because the path was passed to `create`/`Bopen` unexpanded.  
**Fix:** In `dump()`, run the path through `expandhome_c()` before calling `rowdump`/`rowload`.

---

### Files touched

- `src/cmd/acme/dat.h` – `File`: add `ename` / `nename`
- `src/cmd/acme/file.c` – `filesetname`: maintain both name forms; `filerecalcenname`
- `src/cmd/acme/wind.c` – `wincommit` (contracted compare, no apply-on-commit); `winsettag1` (preserve tag when editing, use file name when tag matches or empty)
- `src/cmd/acme/exec.c` – `getname` (promote path: tag first, then file; ignore non-path getarg when narg==0); `get()` (argt fallback to tag); `dump()` (expandhome_c for path)
- `src/cmd/acme/xfid.c` – `xfideventwrite`: pass `&w->tag` to `execute`
- Other call sites (exec, logf, xfid, ruler, look) – use `f->ename` where an external path is required
- `AGENTS.md` – “Tag path and Get” subsection and debugging table entries
