### PR TITLE
import acme changes from 9front

### DIFF
--- a/man/man1/acme.1
+++ b/man/man1/acme.1
@@ -4,7 +4,7 @@ acme, win, awd \- interactive text windows
 .SH SYNOPSIS
 .B acme
 [
-.B -abr
+.B -aibr
 ]
 [
 .B -f
@@ -195,14 +195,20 @@ When a window is in autoindent mode
 command below) and a newline character is typed,
 .I acme
 copies leading white space on the current line to the new line,
-and when a window is
-.BR Put ,
-.I acme
-removes all trailing end-of-line white space before writing the file.
 The option
 .B -a
 causes each window to start in
 autoindent mode.
+.PP
+When a window is in spacesindent mode
+(see the
+.B Spaces
+command below) and a tab character is typed,
+acme indents the line with spaces equal to the current
+tabstop for the window. The option
+.B -i
+causes each window to start in spacesindent
+mode.
 .SS "Directory context
 Each window's tag names a directory: explicitly if the window
 holds a directory; implicitly if it holds a regular file
@@ -468,6 +474,17 @@ Place selected text in snarf buffer.
 .B Sort
 Arrange the windows in the column from top to bottom in lexicographical
 order based on their names.
+.TP
+.B Spaces
+Set the spacesindent mode according to the argument:
+.B on
+and
+.B off
+set the mode for the current window;
+.B ON
+and
+.B OFF
+set the mode for all existing and future windows.
 .TP
 .B Tab
 Set the width of tab stops for this window to the value of the argument, in units of widths of the zero

--- a/man/man4/acme.4
+++ b/man/man4/acme.4
@@ -4,13 +4,24 @@ acme \- control files for text windows
 .SH SYNOPSIS
 .B acme
 [
+.B -ab
+]
+[
+.B -c
+.I ncol
+]
+[
 .B -f
 .I varfont
-] [
+]
+[
 .B -F
 .I fixfont
 ]
 [
+.B -l
+.I file
+|
 .I file
 \&... ]
 .SH DESCRIPTION
@@ -113,9 +124,10 @@ The reported operations are
 (window creation via zerox),
 .LR get ,
 .LR put ,
-and
-.LR del
-(window deletion).
+.L del
+(window deletion), and
+.L focus
+(window focus change).
 The window name can be the empty string; in particular it is empty in
 .L new
 log entries corresponding to windows created by external programs.
@@ -156,18 +168,20 @@ file.
 When read, it returns the value of the address that would next be read
 or written through the
 .B data
-file, in the format
-.BI # m ,# n
-where
+file, formatted as 2 decimal numbers
 .I m
 and
-.I n
-are character (not byte) offsets.  If
-.I m
+.IR n ,
+each formatted in 11 characters plus a blank.
+.I M
 and
 .I n
-are identical, the format is just
-.BI # m\f1.
+are the character (not byte) offsets of the
+beginning and end of the address,
+which would be expressed in
+.I acme 's
+input language as
+.BI # m ,# n \fR.
 Thus a regular expression may be evaluated by writing it to
 .B addr
 and reading it back.
@@ -257,6 +271,15 @@ Cancel
 returning the window to the usual state wherein each modification to the
 body must be undone individually.
 .TP
+.B menu
+Maintain
+.BR Undo ,
+.BR Redo ,
+and
+.B Put
+in the left half of the tag.
+(This is the default for file windows.)
+.TP
 .BI name " name
 Set the name of the window to
 .IR name .
@@ -267,10 +290,33 @@ may be undone in a single
 .B Undo
 interactive command.
 .TP
+.B nomenu
+Do not maintain
+.BR Undo ,
+.BR Redo ,
+and
+.B Put
+in the left half of the tag.
+(This is the default for directory and error windows.)
+.TP
+.B noscroll
+Turn off automatic `scrolling' of the window to show text written to the body.
+.TP
 .B put
 Equivalent to the
 .B Put
 interactive command with no arguments; accepts no arguments.
+.TP
+.B scratch
+Turn off tracking the `dirty' status, the window stays clean.
+.TP
+.B scroll
+Cancel a
+.B noscroll
+message, returning the window to the default state wherein each write
+to the
+.B body
+file causes the window to `scroll' to display the new text.
 .TP
 .B show
 Guarantee at least some of the selected text is visible on the display.
@@ -431,6 +477,15 @@ holds contents of the window tag.  It may be read at any byte offset.
 Text written to
 .B tag
 is always appended; the file offset is ignored.
+.TP
+.B rdsel
+holds the contents of the current selection. It may be read at any byte offset.
+.TP
+.B wrsel
+writing to the
+.B wrsel
+file modifies the text in the selection. Text written always
+replaces the text selected; the file offset is ignored.
 .TP
 .B xdata
 The

--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -78,7 +78,7 @@ threadmain(int argc, char *argv[])
 		}
 		break;
 	case 'a':
-		globalautoindent = TRUE;
+		globalindent[AUTOINDENT] = TRUE;
 		break;
 	case 'b':
 		bartflag = TRUE;
@@ -101,6 +101,9 @@ threadmain(int argc, char *argv[])
 		if(fontnames[1] == nil)
 			goto Usage;
 		break;
+	case 'i':
+		globalindent[SPACESINDENT] = TRUE;
+		break;
 	case 'l':
 		loadfile = ARGF();
 		if(loadfile == nil)
@@ -121,7 +124,7 @@ threadmain(int argc, char *argv[])
 		break;
 	default:
 	Usage:
-		fprint(2, "usage: acme -a -c ncol -f fontname -F fixedwidthfontname -l loadfile -W winsize\n");
+		fprint(2, "usage: acme [-aib] [-c ncol] [-f fontname] [-F fixedwidthfontname] [-l loadfile] [-m mtpt] [-r] [-W winsize]\n");
 		threadexitsall("usage");
 	}ARGEND
 
@@ -194,7 +197,7 @@ threadmain(int argc, char *argv[])
 	cedit = chancreate(sizeof(int), 0);
 	cexit = chancreate(sizeof(int), 0);
 	cwarn = chancreate(sizeof(void*), 1);
-	if(cwait==nil || ccommand==nil || ckill==nil || cxfidalloc==nil || cxfidfree==nil || cerr==nil || cexit==nil || cwarn==nil){
+	if(cwait==nil || ccommand==nil || ckill==nil || cxfidalloc==nil || cxfidfree==nil || cnewwindow==nil || cerr==nil || cedit==nil || cexit==nil || cwarn==nil){
 		fprint(2, "acme: can't create initial channels: %r\n");
 		threadexitsall("channels");
 	}

--- a/src/cmd/acme/cols.c
+++ b/src/cmd/acme/cols.c
@@ -126,6 +126,7 @@ coladd(Column *c, Window *w, Window *clone, int y)
 	}
 	if(w == nil){
 		w = emalloc(sizeof(Window));
+		w->rdselfd = -1;
 		w->col = c;
 		draw(screen, r, textcols[BACK], nil, ZP);
 		wininit(w, clone, r);
@@ -255,11 +256,10 @@ colresize(Column *c, Rectangle r)
 		w->maxlines = 0;
 		if(i == c->nw-1)
 			r1.max.y = r.max.y;
-		else{
+		else {
 			r1.max.y = r1.min.y;
-			if(new > 0 && old > 0 && Dy(w->r) > Border+font->height){
+			if(new > 0 && old > 0 && Dy(w->r) > Border+font->height)
 				r1.max.y += (Dy(w->r)-Border-font->height)*new/old + Border + font->height;
-			}
 		}
 		r1.max.y = max(r1.max.y, r1.min.y + Border+font->height);
 		r2 = r1;

--- a/src/cmd/acme/dat.c
+++ b/src/cmd/acme/dat.c
@@ -42,7 +42,8 @@ char			*objtype;
 char			*acmeshell;
 //char			*fontnames[2];
 extern char		wdir[]; /* must use extern because no dimension given */
-int			globalautoindent;
+int			globalindent[NINDENT];
+Rune			*delcmd;
 int			dodollarsigns;
 
 Channel	*cplumb;		/* chan(Plumbmsg*) */

--- a/src/cmd/acme/dat.h
+++ b/src/cmd/acme/dat.h
@@ -33,7 +33,6 @@ enum
 	Infinity = 		0x7FFFFFFF	/* huge value for regexp address */
 };
 
-#define Buffer AcmeBuffer
 typedef	struct	Block Block;
 typedef	struct	Buffer Buffer;
 typedef	struct	Command Command;
@@ -208,7 +207,7 @@ void		textcolumnate(Text*, Dirlist**, int);
 void		textcommit(Text*, int);
 void		textconstrain(Text*, uint, uint, uint*, uint*);
 void		textdelete(Text*, uint, uint, int);
-void		textdoubleclick(Text*, uint*, uint*);
+void		textstretchsel(Text*, uint*, uint*, int);
 void		textfill(Text*);
 void		textframescroll(Text*, int);
 void		textinit(Text*, File*, Rectangle, Reffont*, Image**);
@@ -229,6 +228,13 @@ void		textsetselect(Text*, uint, uint);
 void		textshow(Text*, uint, uint, int);
 void		texttype(Text*, Rune);
 
+enum
+{
+	SPACESINDENT	= 0,
+	AUTOINDENT,
+	NINDENT,
+};
+
 struct Window
 {
 	QLock	lk;
@@ -238,9 +244,10 @@ struct Window
 	Rectangle	r;
 	uchar	isdir;
 	uchar	isscratch;
+	uchar	noscroll;
 	uchar	filemenu;
 	uchar	dirty;
-	uchar	autoindent;
+	uchar	indent[NINDENT];
 	uchar	showdel;
 	int		id;
 	Range	addr;
@@ -553,7 +560,8 @@ extern char		wdir[]; /* must use extern because no dimension given */
 extern int			editing;
 extern int			erroutfd;
 extern int			messagesize;		/* negotiated in 9P version setup */
-extern int			globalautoindent;
+extern int			globalindent[NINDENT];
+extern Rune			*delcmd;		/* command that ran, for movetodel (Del, Delmesg, ...) */
 extern int			dodollarsigns;
 extern char*		mtpt;
 

--- a/src/cmd/acme/disk.c
+++ b/src/cmd/acme/disk.c
@@ -124,10 +124,20 @@ diskwrite(Disk *d, Block **bp, Rune *r, uint n)
 void
 diskread(Disk *d, Block *b, Rune *r, uint n)
 {
+	int tot, nr;
+	char *p;
+
 	if(n > b->u.n)
 		error("internal error: diskread");
 
 	ntosize(b->u.n, nil);
-	if(pread(d->fd, r, n*sizeof(Rune), b->addr) != n*sizeof(Rune))
+	n *= sizeof(Rune);
+	p = (char*)r;
+	for(tot = 0; tot < n; tot += nr){
+		nr = pread(d->fd, p+tot, n-tot, b->addr+tot);
+		if(nr <= 0)
+			error("read error from temp file");
+	}
+	if(tot != n)
 		error("read error from temp file");
 }

--- a/src/cmd/acme/ecmd.c
+++ b/src/cmd/acme/ecmd.c
@@ -133,11 +133,11 @@ edittext(Window *w, int q, Rune *r, int nr)
 {
 	File *f;
 
-	f = w->body.file;
 	switch(editing){
 	case Inactive:
 		return "permission denied";
 	case Inserting:
+		f = w->body.file;
 		eloginsert(f, q, r, nr);
 		return nil;
 	case Collecting:
@@ -158,11 +158,13 @@ filelist(Text *t, Rune *r, int nr)
 	if(nr == 0)
 		return nil;
 	r = skipbl(r, nr, &nr);
-	if(r[0] != '<')
-		return runestrdup(r);
-	/* use < command to collect text */
 	clearcollection();
-	runpipe(t, '<', r+1, nr-1, Collecting);
+	if(r[0] != '<'){
+		if((collection = runestrdup(r)) != nil)
+			ncollection += runestrlen(r);
+	}else
+		/* use < command to collect text */
+		runpipe(t, '<', r+1, nr-1, Collecting);
 	return collection;
 }
 
@@ -545,7 +547,7 @@ u_cmd(Text *t, Cmd *cp)
 		flag = FALSE;
 	}
 	oseq = -1;
-	while(n-->0 && t->file->seq!=oseq){
+	while(n-->0 && t->file->seq!=0 && t->file->seq!=oseq){
 		oseq = t->file->seq;
 		undo(t, nil, nil, flag, 0, nil, 0);
 	}
@@ -1002,14 +1004,14 @@ filelooper(Text *t, Cmd *cp, int XY)
 	 */
 	allwindows(alllocker, (void*)1);
 	globalincref = 1;
-	
+
 	/*
 	 * Unlock the window running the X command.
 	 * We'll need to lock and unlock each target window in turn.
 	 */
 	if(t && t->w)
 		winunlock(t->w);
-	
+
 	for(i=0; i<loopstruct.nw; i++) {
 		targ = &loopstruct.w[i]->body;
 		if(targ && targ->w)

--- a/src/cmd/acme/exec.c
+++ b/src/cmd/acme/exec.c
@@ -35,7 +35,6 @@ Buffer	snarfbuf;
 void doabort(Text*, Text*, Text*, int, int, Rune*, int);
 void	del(Text*, Text*, Text*, int, int, Rune*, int);
 void	delcol(Text*, Text*, Text*, int, int, Rune*, int);
-void	dotfiles(Text*, Text*, Text*, int, int, Rune*, int);
 void	dump(Text*, Text*, Text*, int, int, Rune*, int);
 void	edit(Text*, Text*, Text*, int, int, Rune*, int);
 void	xexit(Text*, Text*, Text*, int, int, Rune*, int);
@@ -94,6 +93,7 @@ static Rune LSnarf[] = { 'S', 'n', 'a', 'r', 'f', 0 };
 static Rune LSort[] = { 'S', 'o', 'r', 't', 0 };
 static Rune LTab[] = { 'T', 'a', 'b', 0 };
 static Rune LUndo[] = { 'U', 'n', 'd', 'o', 0 };
+static Rune LSpaces[] = { 'S', 'p', 'a', 'c', 'e', 's', 0 };
 static Rune LZerox[] = { 'Z', 'e', 'r', 'o', 'x', 0 };
 
 Exectab exectab[] = {
@@ -109,7 +109,7 @@ Exectab exectab[] = {
 	{ LGet,		get,		FALSE,	TRUE,	XXX		},
 	{ LID,		id,		FALSE,	XXX,		XXX		},
 	{ LIncl,		incl,		FALSE,	XXX,		XXX		},
-	{ LIndent,		indent,	FALSE,	XXX,		XXX		},
+	{ LIndent,		indent,	FALSE,	AUTOINDENT,	XXX		},
 	{ LKill,		xkill,		FALSE,	XXX,		XXX		},
 	{ LLoad,		dump,	FALSE,	FALSE,	XXX		},
 	{ LLocal,		local,	FALSE,	XXX,		XXX		},
@@ -123,6 +123,7 @@ Exectab exectab[] = {
 	{ LSend,		sendx,	TRUE,	XXX,		XXX		},
 	{ LSnarf,		cut,		FALSE,	TRUE,	FALSE	},
 	{ LSort,		sort,		FALSE,	XXX,		XXX		},
+	{ LSpaces,		indent,	FALSE,	SPACESINDENT,	XXX		},
 	{ LTab,		tab,		FALSE,	XXX,		XXX		},
 	{ LUndo,		undo,	FALSE,	TRUE,	XXX		},
 	{ LZerox,		zeroxx,	FALSE,	XXX,		XXX		},
@@ -182,6 +183,8 @@ execute(Text *t, uint aq0, uint aq1, int external, Text *argt)
 	}
 	r = runemalloc(q1-q0);
 	bufread(&t->file->b, q0, r, q1-q0);
+	free(delcmd);
+	delcmd = runesmprint("%.*S", q1-q0, r);
 	e = lookup(r, q1-q0);
 	if(!external && t->w!=nil && t->w->nopen[QWevent]>0){
 		f = 0;
@@ -749,10 +752,10 @@ putfile(File *f, int q0, int q1, Rune *namer, int nname)
 
 	for(q=q0; q<q1; q+=n){
 		n = q1 - q;
-		if(n > BUFSIZE/UTFmax)
-			n = BUFSIZE/UTFmax;
+		if(n > (BUFSIZE-1)/UTFmax)
+			n = (BUFSIZE-1)/UTFmax;
 		bufread(&f->b, q, r, n);
-		m = snprint(s, BUFSIZE+1, "%.*S", n, r);
+		m = snprint(s, BUFSIZE, "%.*S", n, r);
 		sha1((uchar*)s, m, nil, h);
 		if(Bwrite(b, s, m) != m){
 			warning(nil, "can't write file %s: %r\n", name);
@@ -916,7 +919,7 @@ put(Text *et, Text *_0, Text *argt, int _1, int _2, Rune *arg, int narg)
 		warning(nil, "no file name\n");
 		return;
 	}
-	if(w->autoindent)
+	if(w->indent[AUTOINDENT])
 		trimspaces(et);
 	namer = bytetorune(name, &nname);
 	putfile(f, 0, f->b.nc, namer, nname);
@@ -1388,66 +1391,75 @@ incl(Text *et, Text *_0, Text *argt, int _1, int _2, Rune *arg, int narg)
 static Rune LON[] = { 'O', 'N', 0 };
 static Rune LOFF[] = { 'O', 'F', 'F', 0 };
 static Rune Lon[] = { 'o', 'n', 0 };
+static Rune Loff[] = { 'o', 'f', 'f', 0 };
 
 enum {
 	IGlobal = -2,
 	IError = -1,
-	Ion = 0,
-	Ioff = 1
 };
 
 static int
-indentval(Rune *s, int n)
+indentval(Rune *s, int n, int type)
 {
+	static char *strs[] = {
+		[SPACESINDENT] "Spaces",
+		[AUTOINDENT] "Indent",
+	};
+
 	if(n < 2)
 		return IError;
 	if(runestrncmp(s, LON, n) == 0){
-		globalautoindent = TRUE;
-		warning(nil, "Indent ON\n");
+		globalindent[type] = TRUE;
+		warning(nil, "%s ON\n", strs[type]);
 		return IGlobal;
 	}
 	if(runestrncmp(s, LOFF, n) == 0){
-		globalautoindent = FALSE;
-		warning(nil, "Indent OFF\n");
+		globalindent[type] = FALSE;
+		warning(nil, "%s OFF\n", strs[type]);
 		return IGlobal;
 	}
-	return runestrncmp(s, Lon, n) == 0;
+	if(runestrncmp(s, Lon, n) == 0)
+		return TRUE;
+	if(runestrncmp(s, Loff, n) == 0)
+		return FALSE;
+	return IError;
 }
 
 static void
 fixindent(Window *w, void *arg)
 {
-	USED(arg);
-	w->autoindent = globalautoindent;
+	int t;
+
+	t = *(int*)arg;
+	w->indent[t] = globalindent[t];
 }
 
 void
-indent(Text *et, Text *_0, Text *argt, int _1, int _2, Rune *arg, int narg)
+indent(Text *et, Text *_0, Text *argt, int type, int _1, Rune *arg, int narg)
 {
 	Rune *a, *r;
 	Window *w;
-	int na, len, autoindent;
+	int na, len, ival;
 
 	USED(_0);
 	USED(_1);
-	USED(_2);
 
 	w = nil;
 	if(et!=nil && et->w!=nil)
 		w = et->w;
-	autoindent = IError;
+	ival = IError;
 	getarg(argt, FALSE, TRUE, &r, &len);
 	if(r!=nil && len>0)
-		autoindent = indentval(r, len);
+		ival = indentval(r, len, type);
 	else{
 		a = findbl(arg, narg, &na);
 		if(a != arg)
-			autoindent = indentval(arg, narg-na);
+			ival = indentval(arg, narg-na, type);
 	}
-	if(autoindent == IGlobal)
-		allwindows(fixindent, nil);
-	else if(w != nil && autoindent >= 0)
-		w->autoindent = autoindent;
+	if(ival == IGlobal)
+		allwindows(fixindent, &type);
+	else if(w != nil && ival >= 0)
+		w->indent[type] = ival;
 }
 
 void

--- a/src/cmd/acme/fns.h
+++ b/src/cmd/acme/fns.h
@@ -59,6 +59,9 @@ void	get(Text*, Text*, Text*, int, int, Rune*, int);
 void	put(Text*, Text*, Text*, int, int, Rune*, int);
 void	putfile(File*, int, int, Rune*, int);
 void	fontx(Text*, Text*, Text*, int, int, Rune*, int);
+#undef isspace
+#define isspace acmeisspace
+int	isspace(Rune);
 #undef isalnum
 #define isalnum acmeisalnum
 int	isalnum(Rune);

--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -7,7 +7,6 @@
 #include <keyboard.h>
 #include <frame.h>
 #include <fcall.h>
-#include <regexp.h>
 #include <9pclient.h>
 #include <plumb.h>
 #include <libsec.h>
@@ -869,9 +868,11 @@ openfile(Text *t, Expand *e)
 				runemove(rp, ow->incl[i], n);
 				winaddincl(w, rp, n);
 			}
-			w->autoindent = ow->autoindent;
+			for(i=0; i < NINDENT; i++)
+				w->indent[i] = ow->indent[i];
 		}else
-			w->autoindent = globalautoindent;
+			for(i=0; i < NINDENT; i++)
+				w->indent[i] = globalindent[i];
 		xfidlog(w, "new");
 	}
 	if(e->a1 == e->a0)

--- a/src/cmd/acme/scrl.c
+++ b/src/cmd/acme/scrl.c
@@ -47,7 +47,7 @@ void
 scrlresize(void)
 {
 	freeimage(scrtmp);
-	scrtmp = allocimage(display, Rect(0, 0, 32, screen->r.max.y), screen->chan, 0, DNofill);
+	scrtmp = allocimage(display, Rect(0, 0, 32, 3*Dy(screen->r)), screen->chan, 0, DNofill);
 	if(scrtmp == nil)
 		error("scroll alloc");
 }
@@ -70,6 +70,9 @@ textscrdraw(Text *t)
 	r2 = scrpos(r1, t->org, t->org+t->fr.nchars, t->file->b.nc);
 	if(!eqrect(r2, t->lastsr)){
 		t->lastsr = r2;
+		/* move r1, r2 to (0,0) to avoid clipping */
+		r2 = rectsubpt(r2, r1.min);
+		r1 = rectsubpt(r1, r1.min);
 		draw(b, r1, t->fr.cols[BORD], nil, ZP);
 		draw(b, r2, t->fr.cols[BACK], nil, ZP);
 		r2.min.x = r2.max.x-1;

--- a/src/cmd/acme/text.c
+++ b/src/cmd/acme/text.c
@@ -532,6 +532,27 @@ textreadc(Text *t, uint q)
 	return r;
 }
 
+static int
+spacesindentbswidth(Text *t)
+{
+	uint q, col;
+	Rune r;
+
+	col = textbswidth(t, 0x15);
+	q = t->q0;
+	while(q > 0){
+		r = textreadc(t, q-1);
+		if(r != ' ')
+			break;
+		q--;
+		if(--col % t->tabstop == 0)
+			break;
+	}
+	if(t->q0 == q)
+		return 1;
+	return t->q0-q;
+}
+
 int
 textbswidth(Text *t, Rune c)
 {
@@ -540,8 +561,11 @@ textbswidth(Text *t, Rune c)
 	int skipping;
 
 	/* there is known to be at least one character to erase */
-	if(c == 0x08)	/* ^H: erase character */
+	if(c == 0x08){	/* ^H: erase character */
+		if(t->what == Body && t->w->indent[SPACESINDENT])
+			return spacesindentbswidth(t);
 		return 1;
+	}
 	q = t->q0;
 	skipping = TRUE;
 	while(q > 0){
@@ -887,8 +911,19 @@ texttype(Text *t, Rune r)
 			textfill(t->file->text[i]);
 		t->iq1 = t->q0;
 		return;
+	case '\t':
+		if(t->what == Body && t->w->indent[SPACESINDENT]){
+			nnb = textbswidth(t, 0x15);
+			if(nnb == 1 && textreadc(t, t->q0-1) == '\n')
+				nnb = 0;
+			nnb = t->tabstop - nnb % t->tabstop;
+			rp = runemalloc(nnb);
+			for(nr = 0; nr < nnb; nr++)
+				rp[nr] = ' ';
+		}
+		break;
 	case '\n':
-		if(t->w->autoindent){
+		if(t->what == Body && t->w->indent[AUTOINDENT]){
 			/* find beginning of previous line using backspace code */
 			nnb = textbswidth(t, 0x15); /* ^U case */
 			rp = runemalloc(nnb + 1);
@@ -956,6 +991,8 @@ textcommit(Text *t, int tofile)
 
 static	Text	*clicktext;
 static	uint	clickmsec;
+static	int	clickcount;
+static	Point	clickpt;
 static	Text	*selecttext;
 static	uint	selectq;
 
@@ -995,6 +1032,7 @@ textframescroll(Text *t, int dl)
 			textsetselect(t, selectq, t->org+t->fr.p1);
 	}
 	textsetorigin(t, q0, TRUE);
+	flushimage(display, 1);
 }
 
 
@@ -1002,7 +1040,7 @@ void
 textselect(Text *t)
 {
 	uint q0, q1;
-	int b, x, y;
+	int b, x, y, dx, dy;
 	int state;
 	enum { None, Cut, Paste };
 
@@ -1014,25 +1052,36 @@ textselect(Text *t)
 	b = mouse->buttons;
 	q0 = t->q0;
 	q1 = t->q1;
+	dx = abs(clickpt.x - mouse->xy.x);
+	dy = abs(clickpt.y - mouse->xy.y);
+	clickpt = mouse->xy;
 	selectq = t->org+frcharofpt(&t->fr, mouse->xy);
-	if(clicktext==t && mouse->msec-clickmsec<500)
-	if(q0==q1 && selectq==q0){
-		textdoubleclick(t, &q0, &q1);
+	clickcount++;
+	if(mouse->msec-clickmsec >= 500 || selecttext != t || clickcount > 3 || dx > 3 || dy > 3)
+		clickcount = 0;
+	if(clickcount >= 1 && selecttext==t && mouse->msec-clickmsec < 500){
+		textstretchsel(t, &q0, &q1, clickcount);
 		textsetselect(t, q0, q1);
 		flushimage(display, 1);
 		x = mouse->xy.x;
 		y = mouse->xy.y;
 		/* stay here until something interesting happens */
-		do
+		while(1){
 			readmouse(mousectl);
-		while(mouse->buttons==b && abs(mouse->xy.x-x)<3 && abs(mouse->xy.y-y)<3);
+			dx = abs(mouse->xy.x - x);
+			dy = abs(mouse->xy.y - y);
+			if(mouse->buttons != b || dx >= 3 || dy >= 3)
+				break;
+			clickcount++;
+			clickmsec = mouse->msec;
+		}
 		mouse->xy.x = x;	/* in case we're calling frselect */
 		mouse->xy.y = y;
 		q0 = t->q0;	/* may have changed */
 		q1 = t->q1;
-		selectq = q0;
+		selectq = t->org+frcharofpt(&t->fr, mouse->xy);
 	}
-	if(mouse->buttons == b){
+	if(mouse->buttons == b && clickcount == 0){
 		t->fr.scroll = framescroll;
 		frselect(&t->fr, mousectl);
 		/* horrible botch: while asleep, may have lost selection altogether */
@@ -1049,13 +1098,11 @@ textselect(Text *t)
 			q1 = t->org+t->fr.p1;
 	}
 	if(q0 == q1){
-		if(q0==t->q0 && clicktext==t && mouse->msec-clickmsec<500){
-			textdoubleclick(t, &q0, &q1);
-			clicktext = nil;
-		}else{
+		if(q0==t->q0 && mouse->msec-clickmsec<500)
+			textstretchsel(t, &q0, &q1, clickcount);
+		else
 			clicktext = t;
-			clickmsec = mouse->msec;
-		}
+		clickmsec = mouse->msec;
 	}else
 		clicktext = nil;
 	textsetselect(t, q0, q1);
@@ -1072,7 +1119,7 @@ textselect(Text *t)
 			if(b & 2){
 				if(state==Paste && t->what==Body){
 					winundo(t->w, TRUE);
-					textsetselect(t, q0, t->q1);
+					textsetselect(t, q0, t->q0);
 					state = None;
 				}else if(state != Cut){
 					cut(t, t, nil, TRUE, TRUE, nil, 0);
@@ -1094,7 +1141,8 @@ textselect(Text *t)
 		flushimage(display, 1);
 		while(mouse->buttons == b)
 			readmouse(mousectl);
-		clicktext = nil;
+		if(mouse->msec-clickmsec >= 500)
+			clicktext = nil;
 	}
 }
 
@@ -1403,15 +1451,39 @@ Rune *right[] = {
 	nil
 };
 
-void
-textdoubleclick(Text *t, uint *q0, uint *q1)
+static int
+inmode(Rune r, int mode)
 {
-	int c, i;
-	Rune *r, *l, *p;
+	return (mode == 1) ? isalnum(r) : r && !isspacerune(r);
+}
+
+void
+textstretchsel(Text *t, uint *q0, uint *q1, int mode)
+{
+	int c, i, lc, rc;
+	Rune *r, *l, *p, *x;
 	uint q;
+
+	*q0 = t->q0;
+	*q1 = t->q1;
 
 	if(textclickhtmlmatch(t, q0, q1))
 		return;
+
+	if(mode){
+		lc = *q0 > 0    	? textreadc(t, *q0-1) : '\n';
+		rc = *q1 < t->file->b.nc	? textreadc(t, *q1) : '\n';
+		for(i=0; left[i]!=nil; i++){
+			l = left[i];
+			r = right[i];
+			x = runestrchr(l, lc);
+			if(x && r[x-l] == rc){
+				*q0 -= *q0 > 0 && lc != '\n';
+				*q1 += *q1 < t->file->b.nc;
+				return;
+			}
+		}
+	}
 
 	for(i=0; left[i]!=nil; i++){
 		q = *q0;
@@ -1444,12 +1516,11 @@ textdoubleclick(Text *t, uint *q0, uint *q1)
 			return;
 		}
 	}
-
 	/* try filling out word to right */
-	while(*q1<t->file->b.nc && isalnum(textreadc(t, *q1)))
+	while(*q1<t->file->b.nc && inmode(textreadc(t, *q1), mode))
 		(*q1)++;
 	/* try filling out word to left */
-	while(*q0>0 && isalnum(textreadc(t, *q0-1)))
+	while(*q0>0 && inmode(textreadc(t, *q0-1), mode))
 		(*q0)--;
 }
 

--- a/src/cmd/acme/util.c
+++ b/src/cmd/acme/util.c
@@ -107,7 +107,8 @@ errorwin1(Rune *dir, int ndir, Rune **incl, int nincl)
 		runemove(r, incl[i], n);
 		winaddincl(w, r, n);
 	}
-	w->autoindent = globalautoindent;
+	for(i=0; i<NINDENT; i++)
+		w->indent[i] = globalindent[i];
 	return w;
 }
 
@@ -322,6 +323,13 @@ bytetorune(char *s, int *ip)
 	r[nr] = '\0';
 	*ip = nr;
 	return r;
+}
+
+int
+isspace(Rune c)
+{
+	return c == 0 || c == ' ' || c == '\t' ||
+		c == '\n' || c == '\r' || c == '\v';
 }
 
 int

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -21,7 +21,7 @@ wininit(Window *w, Window *clone, Rectangle r)
 	File *f;
 	Reffont *rf;
 	Rune *rp;
-	int nc;
+	int nc, i;
 
 	w->tag.w = w;
 	w->taglines = 1;
@@ -80,10 +80,12 @@ wininit(Window *w, Window *clone, Rectangle r)
 	draw(screen, br, button, nil, button->r.min);
 	w->filemenu = TRUE;
 	w->maxlines = w->body.fr.maxlines;
-	w->autoindent = globalautoindent;
+	for(i=0; i<NINDENT; i++)
+		w->indent[i] = globalindent[i];
 	if(clone){
 		w->dirty = clone->dirty;
-		w->autoindent = clone->autoindent;
+		for(i=0; i<NINDENT; i++)
+			w->indent[i] = clone->indent[i];
 		textsetselect(&w->body, clone->body.q0, clone->body.q1);
 		winsettag(w);
 	}
@@ -108,17 +110,27 @@ windrawbutton(Window *w)
 }
 
 int
-delrunepos(Window *w)
+tagrunepos(Window *w, Rune *s)
 {
-	Rune *r;
-	int i;
+	int n;
+	Rune *r, *rr;
 
-	r = parsetag(w, 0, &i);
-	free(r);
-	i += 2;
-	if(i >= w->tag.file->b.nc)
+	if(s == nil)
 		return -1;
-	return i;
+
+	n = w->tag.file->b.nc;
+	r = runemalloc(n+1);
+	bufread(&w->tag.file->b, 0, r, n);
+	r[n] = L'\0';
+
+	rr = runestrstr(r, s);
+	if(rr == nil || rr == r){
+		free(r);
+		return -1;
+	}
+	n = rr - r;
+	free(r);
+	return n;
 }
 
 void
@@ -126,7 +138,9 @@ movetodel(Window *w)
 {
 	int n;
 
-	n = delrunepos(w);
+	n = tagrunepos(w, delcmd);
+	free(delcmd);
+	delcmd = nil;
 	if(n < 0)
 		return;
 	moveto(mousectl, addpt(frptofchar(&w->tag.fr, n), Pt(4, w->tag.fr.font->height-4)));
@@ -153,7 +167,7 @@ wintaglines(Window *w, Rectangle r)
 
 	if(!w->tagexpand) {
 		/* use just as many lines as needed to show the Del */
-		n = delrunepos(w);
+		n = tagrunepos(w, delcmd);
 		if(n < 0)
 			return 1;
 		p = subpt(frptofchar(&w->tag.fr, n), w->tag.fr.r.min);
@@ -198,6 +212,8 @@ winresize(Window *w, Rectangle r, int safe, int keepextra)
 		w->taglines = wintaglines(w, r);
 		r1.max.y = min(r.max.y, r1.min.y + w->taglines*font->height);
 	}
+	if(Dy(r1) < font->height)
+		r1.max.y = r1.min.y+font->height;
 
 	/* If needed, resize & redraw tag. */
 	y = r1.max.y;
@@ -403,6 +419,8 @@ wintype(Window *w, Text *t, Rune r)
 	int i;
 
 	texttype(t, r);
+	if(t->what == Tag)
+		w->tagsafe = FALSE;
 	if(t->what == Body)
 		for(i=0; i<t->file->ntext; i++)
 			textscrdraw(t->file->text[i]);
@@ -492,6 +510,7 @@ winsettag1(Window *w)
 		old = runemalloc(w->tag.file->b.nc+1);
 		bufread(&w->tag.file->b, 0, old, w->tag.file->b.nc);
 		old[w->tag.file->b.nc] = '\0';
+		w->tagsafe = FALSE;
 	}
 
 	/* compute the text for the whole tag, replacing current only if it differs */
@@ -559,6 +578,7 @@ winsettag1(Window *w)
 				w->tag.q1 = q1+bar;
 			}
 		}
+		w->tagsafe = FALSE;
 	}
 	free(old);
 	free(new);
@@ -570,10 +590,8 @@ winsettag1(Window *w)
 		w->tag.q1 = n;
 	textsetselect(&w->tag, w->tag.q0, w->tag.q1);
 	windrawbutton(w);
-	if(resize){
-		w->tagsafe = 0;
+	if(w->tagsafe == FALSE)
 		winresize(w, w->r, TRUE, TRUE);
-	}
 }
 
 void
@@ -640,13 +658,14 @@ winaddincl(Window *w, Rune *r, int n)
 		r = runerealloc(r, n+1);
 		r[n] = 0;
 	}
-	free(a);
 	if((d->qid.type&QTDIR) == 0){
 		free(d);
 		warning(nil, "%s: not a directory\n", a);
 		free(r);
+		free(a);
 		return;
 	}
+	free(a);
 	free(d);
 	w->nincl++;
 	w->incl = realloc(w->incl, w->nincl*sizeof(Rune*));

--- a/src/cmd/acme/xfid.c
+++ b/src/cmd/acme/xfid.c
@@ -150,10 +150,10 @@ xfidopen(Xfid *x)
 			s = fbufalloc();
 			while(q0 < q1){
 				n = q1 - q0;
-				if(n > BUFSIZE/UTFmax)
-					n = BUFSIZE/UTFmax;
+				if(n > (BUFSIZE-1)/UTFmax)
+					n = (BUFSIZE-1)/UTFmax;
 				bufread(&t->file->b, q0, r, n);
-				m = snprint(s, BUFSIZE+1, "%.*S", n, r);
+				m = snprint(s, BUFSIZE, "%.*S", n, r);
 				if(write(w->rdselfd, s, m) != m){
 					warning(nil, "can't write temp file for pipe command %r\n");
 					break;
@@ -258,7 +258,7 @@ xfidclose(Xfid *x)
 			break;
 		case QWrdsel:
 			close(w->rdselfd);
-			w->rdselfd = 0;
+			w->rdselfd = -1;
 			break;
 		case QWwrsel:
 			w->nomark = FALSE;
@@ -625,20 +625,14 @@ xfidctlwrite(Xfid *x, Window *w)
 	int i, m, n, nb, nr, nulls;
 	Rune *r;
 	char *err, *p, *pp, *q, *e;
-	int isfbuf, scrdraw, settag;
+	int scrdraw, settag;
 	Text *t;
 
 	err = nil;
 	e = x->fcall.data+x->fcall.count;
 	scrdraw = FALSE;
 	settag = FALSE;
-	isfbuf = TRUE;
-	if(x->fcall.count < RBUFSIZE)
-		r = fbufalloc();
-	else{
-		isfbuf = FALSE;
-		r = emalloc(x->fcall.count*UTFmax+1);
-	}
+	r = emalloc(x->fcall.count*UTFmax+1);
 	x->fcall.data[x->fcall.count] = 0;
 	textcommit(&w->tag, TRUE);
 	for(n=0; n<x->fcall.count; n+=m){
@@ -820,6 +814,14 @@ out:
 			wincleartag(w);
 			settag = TRUE;
 			m = 8;
+		}else
+		if(strncmp(p, "scroll", 6) == 0){	/* turn on automatic scrolling (writes to body only) */
+			w->noscroll = FALSE;
+			m = 6;
+		}else
+		if(strncmp(p, "scratch", 7) == 0){ /* mark as a scratch file */
+			w->isscratch = TRUE;
+			m = 7;
 		}else{
 			err = Ebadctl;
 			break;
@@ -828,10 +830,7 @@ out:
 			m++;
 	}
 
-	if(isfbuf)
-		fbuffree(r);
-	else
-		free(r);
+	free(r);
 	if(err)
 		n = 0;
 	fc.count = n;
@@ -849,19 +848,12 @@ xfideventwrite(Xfid *x, Window *w)
 	int m, n;
 	Rune *r;
 	char *err, *p, *q;
-	int isfbuf;
 	Text *t;
 	int c;
 	uint q0, q1;
 
 	err = nil;
-	isfbuf = TRUE;
-	if(x->fcall.count < RBUFSIZE)
-		r = fbufalloc();
-	else{
-		isfbuf = FALSE;
-		r = emalloc(x->fcall.count*UTFmax+1);
-	}
+	r = emalloc(x->fcall.count*UTFmax+1);
 	for(n=0; n<x->fcall.count; n+=m){
 		p = x->fcall.data+n;
 		w->owner = *p++;	/* disgusting */
@@ -915,10 +907,7 @@ xfideventwrite(Xfid *x, Window *w)
 	}
 
     Out:
-	if(isfbuf)
-		fbuffree(r);
-	else
-		free(r);
+	free(r);
 	if(err)
 		n = 0;
 	fc.count = n;
@@ -945,7 +934,7 @@ xfidutfread(Xfid *x, Text *t, uint q1, int qid)
 	off = x->fcall.offset;
 	r = fbufalloc();
 	b = fbufalloc();
-	b1 = fbufalloc();
+	b1 = emalloc(x->fcall.count);
 	n = 0;
 	if(qid==w->utflastqid && off>=w->utflastboff && w->utflastq<=q1){
 		boff = w->utflastboff;
@@ -965,10 +954,10 @@ xfidutfread(Xfid *x, Text *t, uint q1, int qid)
 		w->utflastboff = boff;
 		w->utflastq = q;
 		nr = q1-q;
-		if(nr > BUFSIZE/UTFmax)
-			nr = BUFSIZE/UTFmax;
+		if(nr > (BUFSIZE-1)/UTFmax)
+			nr = (BUFSIZE-1)/UTFmax;
 		bufread(&t->file->b, q, r, nr);
-		nb = snprint(b, BUFSIZE+1, "%.*S", nr, r);
+		nb = snprint(b, BUFSIZE, "%.*S", nr, r);
 		if(boff >= off){
 			m = nb;
 			if(boff+m > off+x->fcall.count)
@@ -992,7 +981,7 @@ xfidutfread(Xfid *x, Text *t, uint q1, int qid)
 	fc.count = n;
 	fc.data = b1;
 	respond(x, &fc, nil);
-	fbuffree(b1);
+	free(b1);
 }
 
 int
@@ -1009,16 +998,16 @@ xfidruneread(Xfid *x, Text *t, uint q0, uint q1)
 	wincommit(w, t);
 	r = fbufalloc();
 	b = fbufalloc();
-	b1 = fbufalloc();
+	b1 = emalloc(x->fcall.count);
 	n = 0;
 	q = q0;
 	boff = 0;
 	while(q<q1 && n<x->fcall.count){
 		nr = q1-q;
-		if(nr > BUFSIZE/UTFmax)
-			nr = BUFSIZE/UTFmax;
+		if(nr > (BUFSIZE-1)/UTFmax)
+			nr = (BUFSIZE-1)/UTFmax;
 		bufread(&t->file->b, q, r, nr);
-		nb = snprint(b, BUFSIZE+1, "%.*S", nr, r);
+		nb = snprint(b, BUFSIZE, "%.*S", nr, r);
 		m = nb;
 		if(boff+m > x->fcall.count){
 			i = x->fcall.count - boff;
@@ -1045,7 +1034,7 @@ xfidruneread(Xfid *x, Text *t, uint q0, uint q1)
 	fc.count = n;
 	fc.data = b1;
 	respond(x, &fc, nil);
-	fbuffree(b1);
+	free(b1);
 	return q-q0;
 }
 


### PR DESCRIPTION
This updates acme to include some very nice features added in 9front. It was much easier to work through applying patches from 9front all in one go, however, that came at the cost of a much larger PR than I would typically prefer. Here are the major changes included in this PR:

1. Indentation: support for indenting with spaces, including backspacing to remove them:
  - [0eddcd84ffd56d52749ad67ba8c4a7e9602f6bf2](https://git.9front.org/plan9front/9front/0eddcd84ffd56d52749ad67ba8c4a7e9602f6bf2/commit.html)
  - [cae5acd68c44a6e94b0a2b0ba3a18d160012efdb](https://git.9front.org/plan9front/9front/cae5acd68c44a6e94b0a2b0ba3a18d160012efdb/commit.html)
  - [9d38818333332444334b2257ae8d9e15feac4a6e](https://git.9front.org/plan9front/9front/9d38818333332444334b2257ae8d9e15feac4a6e/commit.html)

2. Triple click to expand selection:
  - [01ebd966c83f31a116db902394a768c2d3cab628](https://git.9front.org/plan9front/9front/01ebd966c83f31a116db902394a768c2d3cab628/commit.html)
  - [f40b65d5883b5f6d48ead994b1046d8c378a5baa](https://git.9front.org/plan9front/9front/f40b65d5883b5f6d48ead994b1046d8c378a5baa/commit.html)
  - [626eb6de0f82e40f432e7b22a02a1040202d03d5](https://git.9front.org/plan9front/9front/626eb6de0f82e40f432e7b22a02a1040202d03d5/commit.html)
  - [e9ad5734582f70ab160d663360334b2405b247ac](https://git.9front.org/plan9front/9front/e9ad5734582f70ab160d663360334b2405b247ac/commit.html)
3. Stricter channel creation checks: [675fb0a3bbeed7a21721d3579131798233773e74](https://git.9front.org/plan9front/9front/675fb0a3bbeed7a21721d3579131798233773e74/commit.html)
4. More robust disk read: [8dc5e9fd5d16500af1d4f4ba07cde4f23f7be254](https://git.9front.org/plan9front/9front/8dc5e9fd5d16500af1d4f4ba07cde4f23f7be254/commit.html)
5. Apply buffer overrun fix: [d3cbaa85892eefdd928745c83145d1bba4afcc8a](https://git.9front.org/plan9front/9front/d3cbaa85892eefdd928745c83145d1bba4afcc8a/commit.html)
6. Apply warning use after free fix: [32bda0889df63c4c9fa914fe35909cc8e2c41609](https://git.9front.org/plan9front/9front/32bda0889df63c4c9fa914fe35909cc8e2c41609/commit.html)
7. Fix fd checks: [65d772993cf7b1aca3c0516420c2bf83af3ef3fa](https://git.9front.org/plan9front/9front/65d772993cf7b1aca3c0516420c2bf83af3ef3fa/commit.html)
8. Fix resource leak in ecmd: [f4f24d52121a406b77121229b60b873286c08f84](https://git.9front.org/plan9front/9front/f4f24d52121a406b77121229b60b873286c08f84/commit.html)
9. Move mouse to origin of window delete: [f0a4917637d3e6c53449a34ddcfbb11ba73511b7](https://git.9front.org/plan9front/9front/f0a4917637d3e6c53449a34ddcfbb11ba73511b7/commit.html)
10. Scrollbar rendering: [166612aae0bc4c17f86e6e42071ab9ff2fe5233d](https://git.9front.org/plan9front/9front/166612aae0bc4c17f86e6e42071ab9ff2fe5233d/commit.html)
11. Add `scratch` ctl command: [3db2f9012c77291753d9b0132b9ff6d2e05bcd48](https://git.9front.org/plan9front/9front/3db2f9012c77291753d9b0132b9ff6d2e05bcd48/commit.html)
12. Add `scroll` ctl command
13. Updates man pages based on those in 9front to reflect the user facing changes above

